### PR TITLE
RC35: MQTT day/night/auto mode; sets setpoint temperature in type 0x3D depends on current night/day Mode

### DIFF
--- a/src/ems-esp.ino
+++ b/src/ems-esp.ino
@@ -1,6 +1,6 @@
 /*
  * EMS-ESP
- * 
+ *
  * Paul Derbyshire - https://github.com/proddy/EMS-ESP
  *
  * See ChangeLog.md for history
@@ -737,8 +737,10 @@ void MQTTCallback(unsigned int type, const char * topic, const char * message) {
             myDebug("MQTT topic: thermostat mode value %s", message);
             if (strcmp((char *)message, "auto") == 0) {
                 ems_setThermostatMode(2);
-            } else if (strcmp((char *)message, "manual") == 0) {
+            } else if (strcmp((char *)message, "day") == 0) {
                 ems_setThermostatMode(1);
+            } else if (strcmp((char *)message, "night") == 0) {
+                ems_setThermostatMode(0);
             }
         }
 
@@ -863,7 +865,7 @@ void _showerColdShotStop() {
     }
 }
 
-/* 
+/*
  *  Shower Logic
  */
 void showerCheck() {

--- a/src/ems.h
+++ b/src/ems.h
@@ -212,6 +212,7 @@ typedef struct {
     float   setpoint_roomTemp; // current set temp
     float   curr_roomTemp;     // current room temp
     uint8_t mode;              // 0=low, 1=manual, 2=auto
+    bool day_mode;             // 0=night, 1=day
     uint8_t hour;
     uint8_t minute;
     uint8_t second;

--- a/src/ems_devices.h
+++ b/src/ems_devices.h
@@ -7,7 +7,7 @@
 
 #include "ems.h"
 
-/* 
+/*
  * Boiler...
  */
 #define EMS_TYPE_UBAMonitorFast 0x18              // is an automatic monitor broadcast
@@ -27,7 +27,7 @@
 #define EMS_VALUE_UBAParameterWW_wwComfort_Comfort 0x00 // the value for comfort
 #define EMS_VALUE_UBAParameterWW_wwComfort_Eco 0xD8     // the value for eco
 
-/* 
+/*
  * Thermostat...
  */
 
@@ -59,6 +59,7 @@
 #define EMS_OFFSET_RC35Set_mode 7             // position of thermostat mode
 #define EMS_OFFSET_RC35Set_temp_day 2         // position of thermostat setpoint temperature for day time
 #define EMS_OFFSET_RC35Set_temp_night 1       // position of thermostat setpoint temperature for night time
+#define EMS_OFFSET_RC35Get_mode_day 1         // position of thermostat day mode
 
 // Easy specific
 #define EMS_TYPE_EasyStatusMessage 0x0A        // reading values on an Easy Thermostat
@@ -117,7 +118,7 @@ const _Model_Type Model_Types[] = {
     {EMS_MODEL_EASY, 202, 0x18, "TC100 (e.g. Nefit Easy or CT100)"}
 
 };
-/* 
+/*
  * Known thermostat types and their abilities
  */
 const _Thermostat_Type Thermostat_Types[] = {

--- a/src/my_config.h
+++ b/src/my_config.h
@@ -1,8 +1,8 @@
 /*
  * my_config.h
- * 
+ *
  * All configurations and customization's go here
- * 
+ *
  * Paul Derbyshire - https://github.com/proddy/EMS-ESP
  */
 


### PR DESCRIPTION
RC35 Mode: In current 1.3.0 version, the mode can be set to Auto and Manual mode via MQTT only. -> change to night/day/auto mode.
RC35 Temp:  sets setpoint temperature in type 0x3D depends on current night/day Mode