### PR TITLE
Added MQTT Restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These incoming MQTT topics are also handled:
 | thermostat_cmd_mode | TOPIC_THERMOSTAT_CMD_MODE | auto, day, night       | sets the thermostat mode                 |
 | wwactivated         | TOPIC_BOILER_WWACTIVATED  | 0 or 1                 | turns boiler warm water on/off (not tap) |
 | boiler_cmd_wwtemp   | TOPIC_BOILER_CMD_WWTEMP   | temperature as a float | sets the boiler wwtemp current setpoint  |
+| restart             | MQTT_TOPIC_RESTART        | 1                      | restarts the ems-esp device              |
 
 If MQTT is not used use 'set mqtt_host' to remove it.
 

--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -1196,6 +1196,8 @@ void MQTTCallback(unsigned int type, const char * topic, const char * message) {
         myESP.mqttSubscribe(TOPIC_SHOWER_TIMER);
         myESP.mqttSubscribe(TOPIC_SHOWER_ALERT);
         myESP.mqttSubscribe(TOPIC_SHOWER_COLDSHOT);
+        myESP.mqttSubscribe(MQTT_TOPIC_RESTART);
+
 
         // subscribe to a start message and send the first publish
         myESP.mqttSubscribe(MQTT_TOPIC_START);
@@ -1213,6 +1215,12 @@ void MQTTCallback(unsigned int type, const char * topic, const char * message) {
         if (strcmp(topic, MQTT_TOPIC_START) == 0) {
             myDebug("Received boottime: %s", message);
             myESP.setBoottime(message);
+        }
+        
+        // Restart the device
+        if (strcmp(topic, MQTT_TOPIC_RESTART) == 0) {
+            myDebug("Received restart command", message);
+            myESP.resetESP();
         }
 
         // thermostat temp changes

--- a/src/my_config.h
+++ b/src/my_config.h
@@ -22,6 +22,8 @@
 #define MQTT_RETAIN false
 #define MQTT_KEEPALIVE 120 // 2 minutes
 #define MQTT_QOS 1
+#define MQTT_TOPIC_RESTART "restart"
+
 
 // MQTT for thermostat
 #define TOPIC_THERMOSTAT_DATA "thermostat_data"         // for sending thermostat values to MQTT


### PR DESCRIPTION
I wanted to restart my ems-esp device because it seems not responsive every now and then. I can now issue a remote restart through an MQTT message. I am not testing for the payload of `1` but we could add that.
`mosquitto_pub -m "1" -t home/ems-esp/restart`