### PR TITLE
smart tx - try to fix Tx problems

### DIFF
--- a/src/ems.cpp
+++ b/src/ems.cpp
@@ -697,7 +697,7 @@ void _ems_readTelegram(uint8_t * telegram, uint8_t length) {
             } else {
                 // nothing to send so just send a poll acknowledgement back
                 if (EMS_Sys_Status.emsPollEnabled) {
-                    emsaurt_tx_poll();
+                    emsuart_tx_poll();
                 }
             }
         } else if (EMS_Sys_Status.emsTxStatus == EMS_TX_STATUS_WAIT) {
@@ -705,14 +705,14 @@ void _ems_readTelegram(uint8_t * telegram, uint8_t length) {
             if (value == EMS_TX_SUCCESS) {
                 EMS_Sys_Status.emsTxPkgs++;
                 // got a success 01. Send a validate to check the value of the last write
-                emsaurt_tx_poll(); // send a poll to free the EMS bus
+                emsuart_tx_poll(); // send a poll to free the EMS bus
                 _createValidate(); // create a validate Tx request (if needed)
             } else if (value == EMS_TX_ERROR) {
                 // last write failed (04), delete it from queue and dont bother to retry
                 if (EMS_Sys_Status.emsLogging == EMS_SYS_LOGGING_VERBOSE) {
                     myDebug_P(PSTR("** Write command failed from host"));
                 }
-                emsaurt_tx_poll(); // send a poll to free the EMS bus
+                emsuart_tx_poll(); // send a poll to free the EMS bus
                 _removeTxQueue();  // remove from queue
             }
         }
@@ -1052,7 +1052,7 @@ void _processType(_EMS_RxTelegram * EMS_RxTelegram) {
         }
     }
 
-    emsaurt_tx_poll(); // send Acknowledgement back to free the EMS bus since we have the telegram
+    emsuart_tx_poll(); // send Acknowledgement back to free the EMS bus since we have the telegram
 }
 
 

--- a/src/emsuart.h
+++ b/src/emsuart.h
@@ -33,5 +33,5 @@ void ICACHE_FLASH_ATTR emsuart_init();
 void ICACHE_FLASH_ATTR emsuart_stop();
 void ICACHE_FLASH_ATTR emsuart_start();
 void ICACHE_FLASH_ATTR emsuart_tx_buffer(uint8_t * buf, uint8_t len);
-void ICACHE_FLASH_ATTR emsaurt_tx_poll();
+void ICACHE_FLASH_ATTR emsuart_tx_poll();
 void ICACHE_FLASH_ATTR emsuart_tx_brk();


### PR DESCRIPTION
### Add Smart-Tx function
What Smart-Tx does:
Characters are send in loopback mode, w/o any delay. Waits until the send char (incl. BRK) is received. After the whole telegram is send out we expect to receive the whole telegram echo from EMS busmaster.

Because we monitor the send chars via loopback, we can precisely determine the required length for a BRK w/o creating 'ghost characters'.

Smart-Tx is enabled by setting EMS_Sys_Status.emsTxDelay to 2. All other values will keep the old behaviour. So a non-intrusive switch should be possible.

Changes against **dev**
- fix typo - replace emsaurt_tx_poll by emsuart_tx_poll

Fixes / enhancements
- smart tx - enabled by EMS_Sys_Status.emsTxDelay == 2
  using UART loopback mode to send and monitor in burst mode
- change typo: emsaurt_tx_poll to use emsuart_tx_buffer
- encapsulate uart_swap in #ifndef NO_UART_SWAP (private use)