### PR TITLE
Solar Module Junkers ISM1

### DIFF
--- a/src/ems.cpp
+++ b/src/ems.cpp
@@ -61,6 +61,9 @@ void _process_SM100Status(_EMS_RxTelegram * EMS_RxTelegram);
 void _process_SM100Status2(_EMS_RxTelegram * EMS_RxTelegram);
 void _process_SM100Energy(_EMS_RxTelegram * EMS_RxTelegram);
 
+// ISM1
+void _process_ISM1StatusMessage(_EMS_RxTelegram * EMS_RxTelegram);
+
 // HeatPump HP
 void _process_HPMonitor1(_EMS_RxTelegram * EMS_RxTelegram);
 void _process_HPMonitor2(_EMS_RxTelegram * EMS_RxTelegram);
@@ -125,6 +128,7 @@ const _EMS_Type EMS_Types[] = {
     {EMS_MODEL_OTHER, EMS_TYPE_SM100Energy, "SM100Energy", _process_SM100Energy},
     {EMS_MODEL_OTHER, EMS_TYPE_HPMonitor1, "HeatPumpMonitor1", _process_HPMonitor1},
     {EMS_MODEL_OTHER, EMS_TYPE_HPMonitor2, "HeatPumpMonitor2", _process_HPMonitor2},
+    {EMS_MODEL_OTHER, EMS_TYPE_ISM1StatusMessage, "ISM1StatusMessage", _process_ISM1StatusMessage},
 
     // RC10
     {EMS_MODEL_RC10, EMS_TYPE_RCTime, "RCTime", _process_RCTime},
@@ -1466,6 +1470,16 @@ void _process_HPMonitor2(_EMS_RxTelegram * EMS_RxTelegram) {
 
     EMS_Other.HP                = true;
     EMS_Sys_Status.emsRefreshed = true; // triggers a send the values back via MQTT
+}
+
+/*
+ * Junkers ISM1 Solar Module - type 0x0003 EMS+ for energy readings
+ */
+void _process_ISM1StatusMessage(_EMS_RxTelegram * EMS_RxTelegram) {
+    // e.g. B0 00 FF 00 00 03 32 00 00 00 00 13 00 D6 00 00 00 FB D0 F0
+    EMS_Other.SMcollectorTemp  = _toShort(4); // Collector Temperature
+    EMS_Other.SMbottomTemp  = _toShort(6); // Temperature Bottom of Solar Boiler
+    EMS_Other.SM                = true;
 }
 
 /**

--- a/src/ems_devices.h
+++ b/src/ems_devices.h
@@ -48,6 +48,7 @@
 #define EMS_TYPE_SM100Energy 0x028E  // SM100Energy
 #define EMS_TYPE_HPMonitor1 0xE3     // HeatPump Monitor 1
 #define EMS_TYPE_HPMonitor2 0xE5     // HeatPump Monitor 2
+#define EMS_TYPE_ISM1StatusMessage 0x0003  // Solar Module Junkers ISM1 Status
 
 /*
  * Thermostats...
@@ -180,6 +181,7 @@ const _Other_Type Other_Types[] = {
     {EMS_MODEL_OTHER, 163, EMS_ID_SM, "SM100 Solar Module"},
     {EMS_MODEL_OTHER, 171, 0x02, "EMS-OT OpenTherm converter"},
     {EMS_MODEL_OTHER, 252, EMS_ID_HP, "HeatPump Module"}, // warning, fake product id!
+    {EMS_MODEL_OTHER, 101, 0x30, "Junkers ISM1 Solar Controller"}, 
     {EMS_MODEL_OTHER, 189, EMS_ID_GATEWAY, "Web Gateway KM200"}
 
 };


### PR DESCRIPTION
Added support to read out values of a Solar Module Junkers ISM1: 
- collector temperature
- solar boiler temperature.

FYI: This is my first a pull request ever, so I hope I did not make a mess out of it.
