### PR TITLE
Split solar module from other devices

### DIFF
--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -450,22 +450,24 @@ void showInfo() {
     }
 
     // For SM10/SM100 Solar Module
-    if (EMS_Other.SM) {
+    if (ems_getThermostatEnabled()) {
         myDebug_P(PSTR("")); // newline
         myDebug_P(PSTR("%sSolar Module stats:%s"), COLOR_BOLD_ON, COLOR_BOLD_OFF);
-        _renderShortValue("Collector temperature", "C", EMS_Other.SMcollectorTemp);
-        _renderShortValue("Bottom temperature", "C", EMS_Other.SMbottomTemp);
-        _renderIntValue("Pump modulation", "%", EMS_Other.SMpumpModulation);
-        _renderBoolValue("Pump active", EMS_Other.SMpump);
-        _renderShortValue("Energy Last Hour", "Wh", EMS_Other.SMEnergyLastHour, 1); // *10
-        _renderShortValue("Energy Today", "Wh", EMS_Other.SMEnergyToday, 0);
-        _renderShortValue("Energy Total", "kWH", EMS_Other.SMEnergyTotal, 1); // *10
+        myDebug_P(PSTR("  Solar Module: %s"), ems_getSolarModuleDescription(buffer_type));
+        _renderShortValue("Collector temperature", "C", EMS_SolarModule.collectorTemp);
+        _renderShortValue("Bottom temperature", "C", EMS_SolarModule.bottomTemp);
+        _renderIntValue("Pump modulation", "%", EMS_SolarModule.pumpModulation);
+        _renderBoolValue("Pump active", EMS_SolarModule.pump);
+        _renderShortValue("Energy Last Hour", "Wh", EMS_SolarModule.EnergyLastHour, 1); // *10
+        _renderShortValue("Energy Today", "Wh", EMS_SolarModule.EnergyToday, 0);
+        _renderShortValue("Energy Total", "kWH", EMS_SolarModule.EnergyTotal, 1); // *10
     }
 
     // For HeatPumps
     if (EMS_Other.HP) {
         myDebug_P(PSTR("")); // newline
         myDebug_P(PSTR("%sHeat Pump stats:%s"), COLOR_BOLD_ON, COLOR_BOLD_OFF);
+        myDebug_P(PSTR("  Solar Module: %s"), ems_getHeatPumpDescription(buffer_type));
         _renderIntValue("Pump modulation", "%", EMS_Other.HPModulation);
         _renderIntValue("Pump speed", "%", EMS_Other.HPSpeed);
     }
@@ -762,32 +764,32 @@ void publishValues(bool force) {
     // handle the other values separately
 
     // For SM10 and SM100 Solar Modules
-    if (EMS_Other.SM) {
+    if (ems_getSolarModuleEnabled()) {
         // build new json object
         doc.clear();
         JsonObject rootSM = doc.to<JsonObject>();
 
-        if (abs(EMS_Other.SMcollectorTemp) != EMS_VALUE_SHORT_NOTSET)
-            rootSM[SM_COLLECTORTEMP] = (double)EMS_Other.SMcollectorTemp / 10;
+        if (abs(EMS_SolarModule.collectorTemp) != EMS_VALUE_SHORT_NOTSET)
+            rootSM[SM_COLLECTORTEMP] = (double)EMS_SolarModule.collectorTemp / 10;
 
-        if (abs(EMS_Other.SMbottomTemp) != EMS_VALUE_SHORT_NOTSET)
-            rootSM[SM_BOTTOMTEMP] = (double)EMS_Other.SMbottomTemp / 10;
+        if (abs(EMS_SolarModule.bottomTemp) != EMS_VALUE_SHORT_NOTSET)
+            rootSM[SM_BOTTOMTEMP] = (double)EMS_SolarModule.bottomTemp / 10;
 
-        if (EMS_Other.SMpumpModulation != EMS_VALUE_INT_NOTSET)
-            rootSM[SM_PUMPMODULATION] = EMS_Other.SMpumpModulation;
+        if (EMS_SolarModule.pumpModulation != EMS_VALUE_INT_NOTSET)
+            rootSM[SM_PUMPMODULATION] = EMS_SolarModule.pumpModulation;
 
-        if (EMS_Other.SMpump != EMS_VALUE_INT_NOTSET) {
-            rootSM[SM_PUMP] = _bool_to_char(s, EMS_Other.SMpump);
+        if (EMS_SolarModule.pump != EMS_VALUE_INT_NOTSET) {
+            rootSM[SM_PUMP] = _bool_to_char(s, EMS_SolarModule.pump);
         }
 
-        if (abs(EMS_Other.SMEnergyLastHour) != EMS_VALUE_SHORT_NOTSET)
-            rootSM[SM_ENERGYLASTHOUR] = (double)EMS_Other.SMEnergyLastHour / 10;
+        if (abs(EMS_SolarModule.EnergyLastHour) != EMS_VALUE_SHORT_NOTSET)
+            rootSM[SM_ENERGYLASTHOUR] = (double)EMS_SolarModule.EnergyLastHour / 10;
 
-        if (abs(EMS_Other.SMEnergyToday) != EMS_VALUE_SHORT_NOTSET)
-            rootSM[SM_ENERGYTODAY] = EMS_Other.SMEnergyToday;
+        if (abs(EMS_SolarModule.EnergyToday) != EMS_VALUE_SHORT_NOTSET)
+            rootSM[SM_ENERGYTODAY] = EMS_SolarModule.EnergyToday;
 
-        if (abs(EMS_Other.SMEnergyTotal) != EMS_VALUE_SHORT_NOTSET)
-            rootSM[SM_ENERGYTOTAL] = (double)EMS_Other.SMEnergyTotal / 10;
+        if (abs(EMS_SolarModule.EnergyTotal) != EMS_VALUE_SHORT_NOTSET)
+            rootSM[SM_ENERGYTOTAL] = (double)EMS_SolarModule.EnergyTotal / 10;
 
         data[0] = '\0'; // reset data for next package
         serializeJson(doc, data, sizeof(data));
@@ -927,7 +929,7 @@ void do_regularUpdates() {
         myDebugLog("Requesting scheduled EMS device data");
         ems_getThermostatValues();
         ems_getBoilerValues();
-        ems_getOtherValues();
+        ems_getSolarModuleValues();
     }
 }
 

--- a/src/ems.h
+++ b/src/ems.h
@@ -17,11 +17,16 @@
 // Fixed EMS IDs
 #define EMS_ID_ME 0x0B      // our device, hardcoded as the "Service Key"
 #define EMS_ID_BOILER 0x08  // all UBA Boilers have 0x08
-#define EMS_ID_SM 0x30      // Solar Module SM10 and SM100
+#define EMS_ID_SM 0x30      // Solar Module SM10, SM100 and ISM1
 #define EMS_ID_HP 0x38      // HeatPump
 #define EMS_ID_GATEWAY 0x48 // KM200 Web Gateway
 
 #define EMS_PRODUCTID_HEATRONICS 95 // ProductID for a Junkers Heatronic3 device
+
+#define EMS_PRODUCTID_SM10 73 // ProductID for SM10 solar module
+#define EMS_PRODUCTID_SM100 163 // ProductID for SM10 solar module
+#define EMS_PRODUCTID_ISM1 101 // ProductID for SM10 solar module
+
 
 #define EMS_MIN_TELEGRAM_LENGTH 6 // minimal length for a validation telegram, including CRC
 
@@ -159,6 +164,13 @@ typedef struct {
     uint8_t product_id;
     uint8_t device_id;
     char    model_string[50];
+} _SolarModule_Type;
+
+typedef struct {
+    uint8_t model_id;
+    uint8_t product_id;
+    uint8_t device_id;
+    char    model_string[50];
 } _Other_Type;
 
 // Definition for thermostat devices
@@ -241,20 +253,31 @@ typedef struct {           // UBAParameterWW
  * Telegram package defintions for Other EMS devices
  */
 
-// SM Solar Module - SM10Monitor/SM100Monitor
+// Other ems devices than solar modules, thermostats and boilers
 typedef struct {
-    bool    SM;               // set true if there is a Solar Module available
     bool    HP;               // set true if there is a Heat Pump available
-    int16_t SMcollectorTemp;  // collector temp
-    int16_t SMbottomTemp;     // bottom temp
-    uint8_t SMpumpModulation; // modulation solar pump
-    uint8_t SMpump;           // pump active
-    int16_t SMEnergyLastHour;
-    int16_t SMEnergyToday;
-    int16_t SMEnergyTotal;
     uint8_t HPModulation; // heatpump modulation in %
     uint8_t HPSpeed;      // speed 0-100 %
+    uint8_t device_id; // the device ID of the Solar Module / Heat Pump (e.g. 0x30)
+    uint8_t model_id;  // Solar Module / Heat Pump model (e.g. 3 > EMS_MODEL_OTHER )
+    uint8_t product_id; // (e.g. 101)
+    char    version[10];
 } _EMS_Other;
+
+// SM Solar Module - SM10/SM100/ISM1
+typedef struct {
+    int16_t collectorTemp;  // collector temp
+    int16_t bottomTemp;     // bottom temp
+    uint8_t pumpModulation; // modulation solar pump
+    uint8_t pump;           // pump active
+    int16_t EnergyLastHour;
+    int16_t EnergyToday;
+    int16_t EnergyTotal;
+    uint8_t device_id; // the device ID of the Solar Module / Heat Pump (e.g. 0x30)
+    uint8_t model_id;  // Solar Module / Heat Pump model (e.g. 3 > EMS_MODEL_OTHER )
+    uint8_t product_id; // (e.g. 101)
+    char    version[10];
+} _EMS_SolarModule;
 
 // Thermostat data
 typedef struct {
@@ -322,17 +345,22 @@ void ems_setTxDisabled(bool b);
 
 char *           ems_getThermostatDescription(char * buffer);
 char *           ems_getBoilerDescription(char * buffer);
+char *           ems_getSolarModuleDescription(char * buffer);
+char *           ems_getHeatPumpDescription(char * buffer);
 void             ems_getThermostatValues();
 void             ems_getBoilerValues();
-void             ems_getOtherValues();
+void             ems_getSolarModuleValues();
 bool             ems_getPoll();
 bool             ems_getTxEnabled();
 bool             ems_getThermostatEnabled();
 bool             ems_getBoilerEnabled();
+bool             ems_getSolarModuleEnabled();
 bool             ems_getBusConnected();
 _EMS_SYS_LOGGING ems_getLogging();
 bool             ems_getEmsRefreshed();
 uint8_t          ems_getThermostatModel();
+uint8_t          ems_getSolarModuleModel();
+uint8_t          ems_getOtherModel();
 void             ems_discoverModels();
 bool             ems_getTxCapable();
 uint32_t         ems_getPollFrequency();
@@ -350,4 +378,5 @@ void    _removeTxQueue();
 extern _EMS_Sys_Status EMS_Sys_Status;
 extern _EMS_Boiler     EMS_Boiler;
 extern _EMS_Thermostat EMS_Thermostat;
+extern _EMS_SolarModule EMS_SolarModule;
 extern _EMS_Other      EMS_Other;

--- a/src/ems_devices.h
+++ b/src/ems_devices.h
@@ -124,6 +124,9 @@ typedef enum {
     // generic ID for the boiler
     EMS_MODEL_UBA,
 
+    // generic ID for the solar module
+    EMS_MODEL_SOLAR_MODULE,
+
     // generic ID for all the other weird devices
     EMS_MODEL_OTHER,
 
@@ -147,7 +150,7 @@ typedef enum {
 
 } _EMS_MODEL_ID;
 
-// EMS types for known devices. This list will be extended when new devices are recognized.
+// EMS types for known boilers. This list will be extended when new devices are recognized.
 // The device_id is always 0x08
 // format is MODEL_ID, PRODUCT ID, DESCRIPTION
 const _Boiler_Type Boiler_Types[] = {
@@ -164,7 +167,19 @@ const _Boiler_Type Boiler_Types[] = {
 
 };
 
-// Other EMS devices which are not considered boilers or thermostats
+/*
+ * Known Solar Module types
+ */
+const _SolarModule_Type SolarModule_Types[] = {    
+
+    {EMS_MODEL_OTHER, EMS_PRODUCTID_SM10, EMS_ID_SM, "SM10 Solar Module"},
+    {EMS_MODEL_OTHER, EMS_PRODUCTID_SM100, EMS_ID_SM, "SM100 Solar Module"},
+    {EMS_MODEL_OTHER, EMS_PRODUCTID_ISM1, EMS_ID_SM, "Junkers ISM1 Solar Module"}
+
+};
+
+
+// Other EMS devices which are not considered boilers, thermostats or solar modules
 const _Other_Type Other_Types[] = {
 
     {EMS_MODEL_OTHER, 69, 0x21, "MM10 Mixer Module"},
@@ -178,11 +193,8 @@ const _Other_Type Other_Types[] = {
     {EMS_MODEL_OTHER, 125, 0x09, "BC25 Base Controller"},
     {EMS_MODEL_OTHER, 152, 0x09, "Junkers Controller"},
     {EMS_MODEL_OTHER, 205, 0x02, "Nefit Moduline Easy Connect"},
-    {EMS_MODEL_OTHER, 73, EMS_ID_SM, "SM10 Solar Module"},
-    {EMS_MODEL_OTHER, 163, EMS_ID_SM, "SM100 Solar Module"},
     {EMS_MODEL_OTHER, 171, 0x02, "EMS-OT OpenTherm converter"},
     {EMS_MODEL_OTHER, 252, EMS_ID_HP, "HeatPump Module"}, // warning, fake product id!
-    {EMS_MODEL_OTHER, 101, 0x30, "Junkers ISM1 Solar Controller"},
     {EMS_MODEL_OTHER, 189, EMS_ID_GATEWAY, "Web Gateway KM200"}
 
 };


### PR DESCRIPTION
Solar module upgrades:

- A separate Solar Module types list (no longer part of other devices). 
- Made a separate _EMS_SolarModule class (no longer part of _EMS_Other). 
- Updated all code that was impacted by the first 2 changes. 
- Also added a device description for solar modules.

Tests on my setup (telnet & MQTT) work as before.