### PR TITLE
SolarLoggingOnly&Bugfix

### DIFF
--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -323,6 +323,8 @@ void showInfo() {
         myDebug_P(PSTR("  System logging set to Verbose"));
     } else if (sysLog == EMS_SYS_LOGGING_THERMOSTAT) {
         myDebug_P(PSTR("  System logging set to Thermostat only"));
+    } else if (sysLog == EMS_SYS_LOGGING_SOLARMODULE ) {
+        myDebug_P(PSTR("  System logging set to Solar Module only"));
     } else {
         myDebug_P(PSTR("  System logging set to None"));
     }
@@ -1298,7 +1300,10 @@ void TelnetCommandCallback(uint8_t wc, const char * commandLine) {
         } else if (strcmp(second_cmd, "t") == 0) {
             ems_setLogging(EMS_SYS_LOGGING_THERMOSTAT);
             ok = true;
-        } else if (strcmp(second_cmd, "r") == 0) {
+        } else if (strcmp(second_cmd, "s") == 0) {
+            ems_setLogging(EMS_SYS_LOGGING_SOLARMODULE );
+            ok = true;
+        }else if (strcmp(second_cmd, "r") == 0) {
             ems_setLogging(EMS_SYS_LOGGING_RAW);
             ok = true;
         } else if (strcmp(second_cmd, "n") == 0) {

--- a/src/ems.h
+++ b/src/ems.h
@@ -83,6 +83,7 @@ typedef enum {
     EMS_SYS_LOGGING_RAW,        // raw data mode
     EMS_SYS_LOGGING_BASIC,      // only basic read/write messages
     EMS_SYS_LOGGING_THERMOSTAT, // only telegrams sent from thermostat
+    EMS_SYS_LOGGING_SOLARMODULE, // only telegrams sent from thermostat
     EMS_SYS_LOGGING_VERBOSE     // everything
 } _EMS_SYS_LOGGING;
 
@@ -270,6 +271,7 @@ typedef struct {
     int16_t bottomTemp;     // bottom temp
     uint8_t pumpModulation; // modulation solar pump
     uint8_t pump;           // pump active
+    int16_t setpoint_maxBottomTemp;  // setpoint for maximum collector temp
     int16_t EnergyLastHour;
     int16_t EnergyToday;
     int16_t EnergyTotal;

--- a/src/ems_devices.h
+++ b/src/ems_devices.h
@@ -48,7 +48,10 @@
 #define EMS_TYPE_SM100Energy 0x028E       // SM100Energy
 #define EMS_TYPE_HPMonitor1 0xE3          // HeatPump Monitor 1
 #define EMS_TYPE_HPMonitor2 0xE5          // HeatPump Monitor 2
+
 #define EMS_TYPE_ISM1StatusMessage 0x0003 // Solar Module Junkers ISM1 Status
+#define EMS_TYPE_ISM1Set 0x0001           // for setting values of the solar module like max boiler temp
+#define EMS_OFFSET_ISM1Set_MaxBoilerTemp 6   // position of max boiler temp  e.g. 50 in the following example: 90 30 FF 06 00 01 50 (CRC=2C)
 
 /*
  * Thermostats...


### PR DESCRIPTION
- Added solar only logging option
- Added a callback message to set the setpoint of the maximum solar boiler temperature.
-fixed bug with wrong device_id for solar