### PR TITLE
fix(FW120): erroneous setpoint temperature display

### DIFF
--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -586,7 +586,7 @@ void showInfo() {
             // Temperatures are *100
             _renderShortValue("Set room temperature", "C", EMS_Thermostat.setpoint_roomTemp, 10); // *100
             _renderShortValue("Current room temperature", "C", EMS_Thermostat.curr_roomTemp, 10); // *100
-        } else if ((ems_getThermostatModel() == EMS_MODEL_FR10) || (ems_getThermostatModel() == EMS_MODEL_FW100)) {
+        } else if ((ems_getThermostatModel() == EMS_MODEL_FR10) || (ems_getThermostatModel() == EMS_MODEL_FW100) || (ems_getThermostatModel() == EMS_MODEL_FW120)) {
             // Temperatures are *10
             _renderShortValue("Set room temperature", "C", EMS_Thermostat.setpoint_roomTemp, 1); // *10
             _renderShortValue("Current room temperature", "C", EMS_Thermostat.curr_roomTemp, 1); // *10
@@ -814,7 +814,7 @@ void publishValues(bool force) {
                 rootThermostat[THERMOSTAT_SELTEMP] = (double)EMS_Thermostat.setpoint_roomTemp / 100;
             if (EMS_Thermostat.curr_roomTemp != EMS_VALUE_SHORT_NOTSET)
                 rootThermostat[THERMOSTAT_CURRTEMP] = (double)EMS_Thermostat.curr_roomTemp / 100;
-        } else if ((ems_getThermostatModel() == EMS_MODEL_FR10) || (ems_getThermostatModel() == EMS_MODEL_FW100)) {
+        } else if ((ems_getThermostatModel() == EMS_MODEL_FR10) || (ems_getThermostatModel() == EMS_MODEL_FW100) || (ems_getThermostatModel() == EMS_MODEL_FW120)) {
             if (EMS_Thermostat.setpoint_roomTemp != EMS_VALUE_SHORT_NOTSET)
                 rootThermostat[THERMOSTAT_SELTEMP] = (double)EMS_Thermostat.setpoint_roomTemp / 10;
             if (EMS_Thermostat.curr_roomTemp != EMS_VALUE_SHORT_NOTSET)


### PR DESCRIPTION
I'm interested by this project since last year and decided to bought an EMS gateway last month.
Just plugged yesterday and after some settings my boiler and my thermostat are well dectected, what a nice work ! Thanks a lot for that ❤️

Here is a tiny PR to fix a display error for setpoint room temperature for FW120 thermostats (both for `info` command and MQTT)
@proddy has already caught the bug in the following conversation : https://github.com/proddy/EMS-ESP/issues/103#issuecomment-502355567