### PR TITLE
feat(thermostats): display mode for FW100 and FW120 thermostats

### DIFF
--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -409,7 +409,16 @@ uint8_t _getThermostatMode(uint8_t hc_num) {
         } else if (mode == 1) {
             thermoMode = 2; // auto
         }
-    } else { // default for all other thermostats
+    } else if (model == EMS_MODEL_FW100 || model == EMS_MODEL_FW120) {
+        if (mode == 3) {
+            thermoMode = 4;
+        } else if (mode == 2) {
+            thermoMode = 3;
+        } else if (mode == 1) {
+            thermoMode = 0;
+        }
+    }
+    else { // default for all other thermostats
         if (mode == 0) {
             thermoMode = 3; // night
         } else if (mode == 1) {

--- a/src/ems.cpp
+++ b/src/ems.cpp
@@ -1521,14 +1521,17 @@ void _process_RCPLUSStatusMode(_EMS_RxTelegram * EMS_RxTelegram) {
  * FR10 Junkers - type x006F
  */
 void _process_JunkersStatusMessage(_EMS_RxTelegram * EMS_RxTelegram) {
-    if (EMS_RxTelegram->offset == 0) {
+    if (EMS_RxTelegram->offset == 0 && EMS_RxTelegram->data_length > 1) {
         uint8_t hc                   = EMS_THERMOSTAT_DEFAULTHC - 1; // use HC1
         EMS_Thermostat.hc[hc].active = true;
 
         // e.g. for FR10:  90 00 FF 00 00 6F   03 01 00 BE 00 BF
         // e.g. for FW100: 90 00 FF 00 00 6F   03 02 00 D7 00 DA F3 34 00 C4
+
         EMS_Thermostat.hc[hc].curr_roomTemp     = _toShort(EMS_OFFSET_JunkersStatusMessage_curr);     // value is * 10
         EMS_Thermostat.hc[hc].setpoint_roomTemp = _toShort(EMS_OFFSET_JunkersStatusMessage_setpoint); // value is * 10
+        EMS_Thermostat.hc[hc].mode              = _toByte(EMS_OFFSET_JunkersStatusMessage_mode);
+        EMS_Sys_Status.emsRefreshed = true; // triggers a send the values back via MQTT
     }
 }
 

--- a/src/ems_devices.h
+++ b/src/ems_devices.h
@@ -140,6 +140,7 @@
 
 // Junkers FR10, FW100 (EMS Plus)
 #define EMS_TYPE_JunkersStatusMessage 0x6F         // is an automatic thermostat broadcast giving us temps
+#define EMS_OFFSET_JunkersStatusMessage_mode 0    // current mode
 #define EMS_OFFSET_JunkersStatusMessage_setpoint 2 // setpoint temp
 #define EMS_OFFSET_JunkersStatusMessage_curr 4     // current temp
 


### PR DESCRIPTION
Hello,

This PR permits to retreive/display mode for Junkers FW100/120 thermostats.
I was able to test the code successfully with my FW120 but maybe it could be a good idea to test with a FW100 (/cc @Vuego123 )

Few information:
- There is an automatic mode on the device but it is never reported as a distinct mode in telegrams
- During mode switching an `x006F` type message is sent with a data length of 1, I have to ignore it in https://github.com/Neonox31/boiler/blob/589caf33bcc024514ad210ebcc5024b91f83de37/src/ems.cpp#L1524 otherwise the temperature values are reset to zero
- I've setted the `EMS_Sys_Status.emsRefreshed` flag like other models