### PR TITLE
MM100 Status Message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2 beta] 2019-10-
+
 ## [1.9.1] 2019-10-05
 
 ### Added

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,9 +9,16 @@ default_envs = debug
 ;default_envs = tests
 
 [common]
-; -DMYESP_TIMESTAMP -DTESTS -DCRASH -DFORCE_SERIAL -DLOGICANALYZER
-;general_flags = -DFORCE_SERIAL
-general_flags =
+; build options are:
+; -DMYESP_TIMESTAMP
+; -DTESTS
+; -DCRASH
+; -DFORCE_SERIAL
+; -DLOGICANALYZER
+
+;general_flags = -g -w -DNO_GLOBAL_EEPROM -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH -DBEARSSL_SSL_BASIC
+general_flags = -g -w -DNO_GLOBAL_EEPROM
+;general_flags =
 
 [env]
 ;board = esp12e
@@ -19,16 +26,17 @@ board = d1_mini
 framework = arduino
 platform = espressif8266
 lib_deps =
-  ESPAsyncTCP
-  CRC32
-  CircularBuffer
-  OneWire
-  JustWifi
-  AsyncMqttClient
-  ArduinoJson
-  EEPROM_Rotate
-  ESP Async WebServer
-  ESPAsyncUDP
+  https://github.com/bakercp/CRC32
+  https://github.com/rlogiacco/CircularBuffer 
+  https://github.com/PaulStoffregen/OneWire
+  https://github.com/xoseperez/justwifi
+  https://github.com/marvinroger/async-mqtt-client
+  https://github.com/xoseperez/eeprom_rotate
+  https://github.com/bblanchon/ArduinoJson
+  https://github.com/me-no-dev/ESPAsyncTCP
+;  https://github.com/me-no-dev/ESPAsyncWebServer
+  ESPAsyncWebServer#1.2.2
+  https://github.com/me-no-dev/ESPAsyncUDP
 upload_speed = 921600
 monitor_speed = 115200
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,10 +33,9 @@ lib_deps =
   https://github.com/marvinroger/async-mqtt-client
   https://github.com/xoseperez/eeprom_rotate
   https://github.com/bblanchon/ArduinoJson
-  https://github.com/me-no-dev/ESPAsyncTCP
-;  https://github.com/me-no-dev/ESPAsyncWebServer
-  ESPAsyncWebServer#1.2.2
   https://github.com/me-no-dev/ESPAsyncUDP
+  https://github.com/me-no-dev/ESPAsyncTCP
+  https://github.com/me-no-dev/ESPAsyncWebServer#b0c6144
 upload_speed = 921600
 monitor_speed = 115200
 
@@ -83,4 +82,3 @@ extra_scripts = pre:scripts/rename_fw.py
 build_type = debug
 build_flags = ${common.general_flags} -Wall
 extra_scripts = scripts/checkcode.py
-

--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -449,10 +449,11 @@ void showInfo() {
         myDebug_P(PSTR("  %d external temperature sensor%s found"), EMSESP_Settings.dallas_sensors, (EMSESP_Settings.dallas_sensors == 1) ? "" : "s");
     }
 
-    myDebug_P(PSTR("  Boiler is %s, Thermostat is %s, Solar Module is %s, Shower Timer is %s, Shower Alert is %s"),
+    myDebug_P(PSTR("  Boiler is %s, Thermostat is %s, Solar Module is %s, Mixing Module is %s, Shower Timer is %s, Shower Alert is %s"),
               (ems_getBoilerEnabled() ? "enabled" : "disabled"),
               (ems_getThermostatEnabled() ? "enabled" : "disabled"),
               (ems_getSolarModuleEnabled() ? "enabled" : "disabled"),
+              (ems_getMixingDeviceEnabled() ? "enabled" : "disabled"),
               ((EMSESP_Settings.shower_timer) ? "enabled" : "disabled"),
               ((EMSESP_Settings.shower_alert) ? "enabled" : "disabled"));
 
@@ -662,6 +663,19 @@ void showInfo() {
                 } else if (thermoMode == 4) {
                     myDebug_P(PSTR("   Mode is set to day"));
                 }
+            }
+        }
+    }
+
+    // Mixing modules sensors
+    if (ems_getMixingDeviceEnabled()) {
+        myDebug_P(PSTR("")); // newline
+        myDebug_P(PSTR("%sMixing module stats:%s"), COLOR_BOLD_ON, COLOR_BOLD_OFF);
+
+        for (uint8_t hc_num = 1; hc_num <= EMS_THERMOSTAT_MAXHC; hc_num++) {
+            if (EMS_Mixing.hc[hc_num - 1].active) {
+                myDebug_P(PSTR(" Mixing Circuit %d"), hc_num);  
+                _renderShortValue("  Current flow temperature", "C", EMS_Mixing.hc[hc_num - 1].flowTemp); 
             }
         }
     }

--- a/src/ems.h
+++ b/src/ems.h
@@ -132,6 +132,7 @@
 #define EMS_MODELTYPE_HP 4         // success color
 #define EMS_MODELTYPE_OTHER 5      // no color
 #define EMS_MODELTYPE_UNKNOWN 6    // no color
+#define EMS_MODELTYPE_MIXING 7
 
 #define EMS_MODELTYPE_UNKNOWN_STRING "unknown?" // model type text to use when discovering an unknown device
 
@@ -273,6 +274,12 @@ typedef struct {
     bool    write_supported;
 } _Thermostat_Device;
 
+typedef struct {
+    uint8_t product_id;
+    uint8_t device_id;
+    char    model_string[50];
+} _Mixing_Device;
+
 // for consolidating all types
 typedef struct {
     uint8_t model_type; // 1=boiler, 2=thermostat, 3=sm, 4=other, 5=unknown
@@ -281,6 +288,7 @@ typedef struct {
     char    version[10];
     char    model_string[50];
 } _Generic_Device;
+
 
 /*
  * Telegram package defintions
@@ -364,6 +372,23 @@ typedef struct {
     uint8_t product_id;
     char    version[10];
 } _EMS_Other;
+
+typedef struct {
+    uint8_t device_id;
+    uint8_t model_id;
+    uint8_t product_id;
+    char    version[10];
+    uint8_t hc;                // heating circuit 1,2, 3 or 4
+    bool    active;            // true if there is data for this HC
+
+    uint8_t flowTemp;
+} _EMS_Mixing_HC;
+
+// Mixer data
+typedef struct {
+    bool           detected;
+    _EMS_Mixing_HC hc[EMS_THERMOSTAT_MAXHC]; // array for the 4 heating circuits
+} _EMS_Mixing;
 
 // SM Solar Module - SM10/SM100/ISM1
 typedef struct {
@@ -464,6 +489,7 @@ void             ems_getSolarModuleValues();
 bool             ems_getPoll();
 bool             ems_getTxEnabled();
 bool             ems_getThermostatEnabled();
+bool             ems_getMixingDeviceEnabled();
 bool             ems_getBoilerEnabled();
 bool             ems_getSolarModuleEnabled();
 bool             ems_getHeatPumpEnabled();
@@ -492,5 +518,6 @@ extern _EMS_Thermostat  EMS_Thermostat;
 extern _EMS_SolarModule EMS_SolarModule;
 extern _EMS_HeatPump    EMS_HeatPump;
 extern _EMS_Other       EMS_Other;
+extern _EMS_Mixing      EMS_Mixing;
 
 extern std::list<_Generic_Device> Devices;

--- a/src/ems_devices.h
+++ b/src/ems_devices.h
@@ -143,6 +143,13 @@
 #define EMS_OFFSET_JunkersStatusMessage_setpoint 2 // setpoint temp
 #define EMS_OFFSET_JunkersStatusMessage_curr 4     // current temp
 
+// MM100 (EMS Plus)
+#define EMS_TYPE_MMPLUSStatusMessage_HC1 0x01D7     // mixer status HC1
+#define EMS_TYPE_MMPLUSStatusMessage_HC2 0x01D8     // mixer status HC2
+#define EMS_TYPE_MMPLUSStatusMessage_HC3 0x01D9     // mixer status HC3
+#define EMS_TYPE_MMPLUSStatusMessage_HC4 0x01DA     // mixer status HC4
+#define EMS_OFFSET_MMPLUSStatusMessage_flow_temp 3  // flow temperature
+
 
 // Known EMS devices
 typedef enum {
@@ -174,7 +181,10 @@ typedef enum {
     EMS_MODEL_FR10,
     EMS_MODEL_FR100,
     EMS_MODEL_FR110,
-    EMS_MODEL_FW120
+    EMS_MODEL_FW120,
+
+    // mixing devices
+    EMS_MODEL_MM100
 
 } _EMS_MODEL_ID;
 
@@ -209,6 +219,11 @@ const _SolarModule_Device SolarModule_Devices[] = {
 
 };
 
+const _Mixing_Device Mixing_Devices[] = {
+    {160, 0x20, "MM100 Mixing Module"},
+    {160, 0x21, "MM100 Mixing Module"},
+};
+
 // Other EMS devices which are not considered boilers, thermostats or solar modules
 // format is PRODUCT ID, DEVICE ID, DESCRIPTION
 const _Other_Device Other_Devices[] = {
@@ -216,8 +231,6 @@ const _Other_Device Other_Devices[] = {
     {71, 0x11, "WM10 Switch Module"},
 
     {69, 0x21, "MM10 Mixer Module"},
-    {160, 0x20, "MM100 Mixing Module"},
-    {160, 0x21, "MM100 Mixing Module"},
     {159, 0x21, "MM50 Mixing Module"},
 
     {68, 0x09, "BC10/RFM20 Receiver"},

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define APP_VERSION "1.9.1"
+#define APP_VERSION "1.9.2b1"

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define APP_VERSION "1.9.1b12"
+#define APP_VERSION "1.9.1"


### PR DESCRIPTION
I have added support form EMS+ Status Message form MM100 modules
```
(01:28:57.393) 0x21 -> all, type 0x01D8, telegram: 21 00 FF 00 01 D8 00 02 00 00 EE 00 00 00 03 (CRC=C9) #data=9

00 EE -> 238 -> 23,8 C

(01:28:25.489) 0x20 -> all, type 0x01D7, telegram: 20 00 FF 00 01 D7 00 02 00 00 F1 00 00 00 03 (CRC=21) #data=9

00 F1 -> 241 -> 24,1 C
```

Those values represent the egress water flow temperature from a MM100 mixing device.