### PR TITLE
Bugfix/issue 238 multiple thermostats

### DIFF
--- a/src/TelnetSpy.cpp
+++ b/src/TelnetSpy.cpp
@@ -439,7 +439,7 @@ void TelnetSpy::setDebugOutput(bool en) {
         actualObject = this;
 
 #ifdef ESP8266
-        os_install_putc1((void *)TelnetSpy_putc); // Set system printing (os_printf) to TelnetSpy
+        os_install_putc1((fp_putc_t)TelnetSpy_putc); // Set system printing (os_printf) to TelnetSpy
         system_set_os_print(true);
 #endif
 
@@ -447,7 +447,7 @@ void TelnetSpy::setDebugOutput(bool en) {
         if (actualObject == this) {
 #ifdef ESP8266
             system_set_os_print(false);
-            os_install_putc1((void *)TelnetSpy_ignore_putc); // Ignore system printing
+            os_install_putc1((fp_putc_t)TelnetSpy_ignore_putc); // Ignore system printing
 #endif
 
             actualObject = NULL;

--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -1464,11 +1464,11 @@ void MQTTCallback(unsigned int type, const char * topic, const char * message) {
         char topic_s[50];
         char buffer[4];
         for (uint8_t hc = 1; hc <= EMS_THERMOSTAT_MAXHC; hc++) {
-            strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_TEMP, sizeof(topic_s));
+            strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_TEMP_HA, sizeof(topic_s));
             strlcat(topic_s, itoa(hc, buffer, 10), sizeof(topic_s));
             myESP.mqttSubscribe(topic_s);
 
-            strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_MODE, sizeof(topic_s));
+            strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_MODE_HA, sizeof(topic_s));
             strlcat(topic_s, itoa(hc, buffer, 10), sizeof(topic_s));
             myESP.mqttSubscribe(topic_s);
         }

--- a/src/ems.cpp
+++ b/src/ems.cpp
@@ -2064,10 +2064,18 @@ void _process_Version(_EMS_RxTelegram * EMS_RxTelegram) {
         // its a known thermostat, add to list
         _addDevice(EMS_MODELTYPE_THERMOSTAT, EMS_RxTelegram->src, product_id, version, i);
 
-        // if we don't have a thermostat set, use this one. it will pick the first one.
-        if (((EMS_Thermostat.device_id == EMS_ID_NONE) || (EMS_Thermostat.model_id == EMS_MODEL_NONE)
+        // if we don't have a thermostat set, use this one. it will pick the first one. but it will
+        // repick if the current one is not writable and the new one is.
+        // if (((EMS_Thermostat.device_id == EMS_ID_NONE) || (EMS_Thermostat.model_id == EMS_MODEL_NONE)
+        //      || (EMS_Thermostat.device_id == Thermostat_Devices[i].device_id))
+        //     && EMS_Thermostat.product_id == EMS_ID_NONE) {
+        if ((((EMS_Thermostat.device_id == EMS_ID_NONE)
+             || (EMS_Thermostat.model_id == EMS_MODEL_NONE)
              || (EMS_Thermostat.device_id == Thermostat_Devices[i].device_id))
-            && EMS_Thermostat.product_id == EMS_ID_NONE) {
+            && (EMS_Thermostat.product_id == EMS_ID_NONE))
+            || ((EMS_Thermostat.product_id != EMS_ID_NONE)
+             && Thermostat_Devices[i].write_supported
+             && !EMS_Thermostat.write_supported)) {
             /*
             myDebug_P(PSTR("* Setting Thermostat to %s (DeviceID:0x%02X ProductID:%d Version:%s)"),
                       Thermostat_Devices[i].model_string,


### PR DESCRIPTION
This PR fixes 3 bugs:
1) Wrong MQTT topics were used in the code for setting mode and temperature.
2) Prefer a writeable thermostat (see issue 238) if more than one thermostat are detected.
3) Fix a small compiler warning regarding unsafe void* usage.