### PR TITLE
revert back subscription of only active heating circuits

### DIFF
--- a/src/ems-esp.cpp
+++ b/src/ems-esp.cpp
@@ -1448,16 +1448,13 @@ void MQTTCallback(unsigned int type, const char * topic, const char * message) {
         char topic_s[50];
         char buffer[4];
         for (uint8_t hc = 1; hc <= EMS_THERMOSTAT_MAXHC; hc++) {
-            // subscribe onlyto active hc
-            if (EMS_Thermostat.hc[hc - 1].active) {
-                strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_TEMP_HA, sizeof(topic_s));
-                strlcat(topic_s, itoa(hc, buffer, 10), sizeof(topic_s));
-                myESP.mqttSubscribe(topic_s);
+            strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_TEMP_HA, sizeof(topic_s));
+            strlcat(topic_s, itoa(hc, buffer, 10), sizeof(topic_s));
+            myESP.mqttSubscribe(topic_s);
 
-                strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_MODE_HA, sizeof(topic_s));
-                strlcat(topic_s, itoa(hc, buffer, 10), sizeof(topic_s));
-                myESP.mqttSubscribe(topic_s);
-            }
+            strlcpy(topic_s, TOPIC_THERMOSTAT_CMD_MODE_HA, sizeof(topic_s));
+            strlcat(topic_s, itoa(hc, buffer, 10), sizeof(topic_s));
+            myESP.mqttSubscribe(topic_s);
         }
 
         // generic incoming MQTT command for Thermostat


### PR DESCRIPTION
Sorry, i found a problem with my changes to the mqtt subscription to only active hc's. Sometimes the thermostate is detected after the mqtt connection and then no circuit is subscriped.  