### PR TITLE
Uart mode 5

### DIFF
--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -571,10 +571,10 @@ void EMSESP::incoming_telegram(uint8_t * data, const uint8_t length) {
     if (((first_value & 0x7F) == txservice_.ems_bus_id()) && (length > 1)) {
         // if we ask ourself at roomcontrol for version e.g. 0B 98 02 00 20
         Roomctrl::check((data[1] ^ 0x80 ^ rxservice_.ems_mask()), data);
-#ifdef EMSESP_DEBUG
+// #ifdef EMSESP_DEBUG
         // get_uptime is only updated once per loop, does not give the right time
         LOG_DEBUG(F("[DEBUG] Echo after %d ms: %s"), ::millis() - tx_time_, Helpers::data_to_hex(data, length).c_str());
-#endif
+// #endif
         return; // it's an echo
     }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -359,11 +359,11 @@ bool Helpers::hasValue(const int8_t v) {
 }
 
 bool Helpers::hasValue(const int16_t v) {
-    return (v != EMS_VALUE_SHORT_NOTSET);
+    return (v != EMS_VALUE_SHORT_NOTSET && v != EMS_VALUE_USHORT_NOTSET && v != EMS_VALUE_SHORT_INVALID && v != EMS_VALUE_USHORT_INVALID);
 }
 
 bool Helpers::hasValue(const uint16_t v) {
-    return (v != EMS_VALUE_USHORT_NOTSET);
+    return (v != EMS_VALUE_SHORT_NOTSET && v != EMS_VALUE_USHORT_NOTSET && v != EMS_VALUE_SHORT_INVALID && v != EMS_VALUE_USHORT_INVALID);
 }
 
 bool Helpers::hasValue(const uint32_t v) {

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -270,7 +270,9 @@ void RxService::add(uint8_t * data, uint8_t length) {
     uint8_t   message_length; // length of the message block, excluding CRC
 
     // work out depending on the type, where the data message block starts and the message length
-    if (data[2] < 0xF0) {
+    // EMS 1 has type_id always in data[2], if it gets a ems+ inquiery it will reply with FF but short length
+    // i.e. sending 0b A1 FF 00 01 D8 20 to a MM10 Mixer (ems1.0) he replys with 21 0B FF 00
+    if (data[2] < 0xF0 || length < 6) {
         // EMS 1.0
         type_id        = data[2];
         message_data   = data + 4;

--- a/src/uart/emsuart_esp32.cpp
+++ b/src/uart/emsuart_esp32.cpp
@@ -60,13 +60,25 @@ void IRAM_ATTR EMSuart::emsuart_rx_intr_handler(void * para) {
     static uint8_t rxbuf[EMS_MAXBUFFERSIZE];
     static uint8_t length;
 
+    if (EMS_UART.int_st.rxfifo_full) {
+        EMS_UART.int_clr.rxfifo_full = 1;
+        emsTxBufIdx++;
+        if (emsTxBufIdx < emsTxBufLen) {
+            EMS_UART.conf1.rxfifo_full_thrhd = emsTxBufId + 1;
+            EMS_UART.fifo.rw_byte            = emsTxBuf[emsTxBufIdx];
+        } else  if (emsTxBufIdx == emsTxBufLen) {
+            EMS_UART.conf0.txd_brk           = 1; // <brk> after send
+            EMS_UART.int_ena.rxfifo_full     = 0;
+            EMS_UART.conf1.rxfifo_full_thrhd = 0x7F;
+        }
+    }
     if (EMS_UART.int_st.brk_det) {
         EMS_UART.int_clr.brk_det = 1; // clear flag
         if (emsTxBufIdx < emsTxBufLen) { // timer tx_mode is interrupted by <brk>
             emsTxBufIdx = emsTxBufLen;   // stop timer mode
             drop_next_rx = true;         // we have trash in buffer
         }
-        length                   = 0;
+        length = 0;
         while (EMS_UART.status.rxfifo_cnt) {
             uint8_t rx = EMS_UART.fifo.rw_byte; // read all bytes from fifo
             if (length < EMS_MAXBUFFERSIZE) {
@@ -169,6 +181,13 @@ void EMSuart::send_poll(uint8_t data) {
         emsTxBufLen           = 1;
         timerAlarmWrite(timer, emsTxWait, false);
         timerAlarmEnable(timer);
+    } else if (tx_mode_ == 5) {
+        EMS_UART.fifo.rw_byte            = data;
+        emsTxBufIdx                      = 0;
+        emsTxBufLen                      = 1;
+        EMS_UART.conf1.rxfifo_full_thrhd = 1;
+        EMS_UART.int_ena.rxfifo_full     = 1;
+        return EMS_TX_STATUS_OK;
     } else if (tx_mode_ == EMS_TXMODE_NEW) {
         EMS_UART.fifo.rw_byte  = data;
         EMS_UART.conf0.txd_brk = 1; // <brk> after send
@@ -214,6 +233,17 @@ uint16_t EMSuart::transmit(uint8_t * buf, uint8_t len) {
         emsTxBufLen           = len;
         timerAlarmWrite(timer, emsTxWait, false);
         timerAlarmEnable(timer);
+        return EMS_TX_STATUS_OK;
+    }
+    if (tx_mode_ == 5) {
+        for (uint8_t i = 0; i < len; i++) {
+            emsTxBuf[i] = buf[i];
+        }
+        EMS_UART.fifo.rw_byte            = buf[0];
+        emsTxBufIdx                      = 0;
+        emsTxBufLen                      = len;
+        EMS_UART.conf1.rxfifo_full_thrhd = 1;
+        EMS_UART.int_ena.rxfifo_full     = 1;
         return EMS_TX_STATUS_OK;
     }
     if (tx_mode_ == EMS_TXMODE_NEW) { // hardware controlled modes

--- a/src/uart/emsuart_esp8266.h
+++ b/src/uart/emsuart_esp8266.h
@@ -46,7 +46,7 @@
 
 // EMS 1.0
 #define EMSUART_TX_BUSY_WAIT (EMSUART_TX_BIT_TIME / 8) // 13
-#define EMSUART_TX_TIMEOUT (22 * EMSUART_TX_BIT_TIME / EMSUART_TX_BUSY_WAIT) // 176
+#define EMSUART_TX_TIMEOUT (32 * EMSUART_TX_BIT_TIME / EMSUART_TX_BUSY_WAIT) // equivaltent to 32 bittimes
 
 // HT3/Junkers - Time to send one Byte (8 Bits, 1 Start Bit, 1 Stop Bit) plus 7 bit delay. The -8 is for lag compensation.
 // since we use a faster processor the lag is negligible


### PR DESCRIPTION
Can you test this tx_mode 5 on your system, it's same readback-logic as mode 1 but working with the rx-interrupt. Debug logging while sending result in the same issues as the timer-modes, seems the logger blocks all interrupts for some ms. 

Another change: there is alway a bit confusion with the short/ushort notsets, some values 0x7D00, some 0x0800, some 0x8300. 