### PR TITLE
do not call shell while sending

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -434,7 +434,13 @@ void Console::loop() {
     telnet_.loop();
 #endif
 
+#if defined(ESP8266)
+    if (!EMSuart::sending()) {
+        Shell::loop_all();
+    }
+#else
     Shell::loop_all();
+#endif
 }
 
 } // namespace emsesp

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -453,11 +453,6 @@ void TxService::send_telegram(const QueuedTxTelegram & tx_telegram) {
 
     length++; // add one since we want to now include the CRC
 
-// logging interferes with the UART so disable this
-#if defined(ESP8266)
-    if (Settings().ems_tx_mode() <= 4) {
-#endif
-        // This logging causes errors with timer based tx-modes on esp8266!
         LOG_DEBUG(F("Sending %s Tx [#%d], telegram: %s"),
                   (telegram->operation == Telegram::Operation::TX_WRITE) ? F("write") : F("read"),
                   tx_telegram.id_,
@@ -468,9 +463,6 @@ void TxService::send_telegram(const QueuedTxTelegram & tx_telegram) {
         if (EMSESP::watch() == EMSESP::Watch::WATCH_RAW) {
             LOG_NOTICE(F("[DEBUG] Tx: %s"), Helpers::data_to_hex(telegram_raw, length).c_str());
         }
-#endif
-#if defined(ESP8266)
-    }
 #endif
 
     // send the telegram to the UART Tx

--- a/src/uart/emsuart_esp8266.h
+++ b/src/uart/emsuart_esp8266.h
@@ -70,6 +70,9 @@ class EMSuart {
     static void ICACHE_FLASH_ATTR     restart();
     static void ICACHE_FLASH_ATTR     send_poll(uint8_t data);
     static uint16_t ICACHE_FLASH_ATTR transmit(uint8_t * buf, uint8_t len);
+    static bool                       sending() {
+      return sending_;
+    }
 
     typedef struct {
         uint8_t length;
@@ -82,6 +85,7 @@ class EMSuart {
     static void ICACHE_FLASH_ATTR emsuart_flush_fifos();
     static void ICACHE_FLASH_ATTR tx_brk();
     static void ICACHE_RAM_ATTR   emsuart_tx_timer_intr_handler();
+    static bool                   sending_;
 };
 
 } // namespace emsesp


### PR DESCRIPTION
It was not the logger which blocks interrupts, it's the shell (syslog debug gives no tx-errors). 
When calling shell after sending is finished all tx-modes work well, also with full debug messages.

I changed tx_mode 5 to 1,5 stopbits, maybe his works with your system. Since mode 5 uses the same logic as mode 1, both should work, but mode 1 can be a bittime/8 slower, due to the waitingcycles. 
But if timermodes works uninterrupted, this mode maybe is needless,