### PR TITLE
fix fluctuating bitvalues, fix "send telegram", add solarpump softsta…

### DIFF
--- a/src/devices/boiler.cpp
+++ b/src/devices/boiler.cpp
@@ -675,6 +675,8 @@ void Boiler::process_UBAErrorMessage(std::shared_ptr<const Telegram> telegram) {
 void Boiler::set_warmwater_temp(const uint8_t temperature) {
     LOG_INFO(F("Setting boiler warm water temperature to %d C"), temperature);
     write_command(EMS_TYPE_UBAParameterWW, 2, temperature);
+    // for i9000, see #397
+    write_command(EMS_TYPE_UBAFlags, 3, temperature);
 }
 
 // flow temp
@@ -846,8 +848,7 @@ void Boiler::console_commands(Shell & shell, unsigned int context) {
                 set_warmwater_mode(1);
             } else if (arguments[0] == read_flash_string(F_(eco))) {
                 set_warmwater_mode(2);
-            }
-            if (arguments[0] == read_flash_string(F_(intelligent))) {
+            } else if (arguments[0] == read_flash_string(F_(intelligent))) {
                 set_warmwater_mode(3);
             } else {
                 shell.println(F("Invalid value. Must be hot, eco or intelligent"));

--- a/src/devices/solar.cpp
+++ b/src/devices/solar.cpp
@@ -181,7 +181,11 @@ void Solar::process_SM100Config(std::shared_ptr<const Telegram> telegram) {
  *      30 00 FF 09 02 64 1E = 30%
  */
 void Solar::process_SM100Status(std::shared_ptr<const Telegram> telegram) {
+    uint8_t pumpmod = pumpModulation_;
     telegram->read_value(pumpModulation_, 9);
+    if (pumpmod == 0 && pumpModulation_ == 100) { // mask out boosts
+        pumpModulation_ = 15; // set to minimum, 
+    }
 }
 
 /*

--- a/src/telegram.h
+++ b/src/telegram.h
@@ -81,11 +81,12 @@ class Telegram {
 
     // reads a bit value from a given telegram position
     void read_bitvalue(uint8_t & value, const uint8_t index, const uint8_t bit) const {
-        if ((index - offset) >= message_length) {
+        uint8_t abs_index = (index - offset); 
+        if(abs_index >= message_length) {
             return; // out of bounds
         }
 
-        value = (uint8_t)(((message_data[index - offset]) >> (bit)) & 0x01);
+        value = (uint8_t)(((message_data[abs_index]) >> (bit)) & 0x01);
     }
 
     // read values from a telegram. We always store the value, regardless if its garbage


### PR DESCRIPTION
- i'm not sure why the bitvalues were fluctuating, i think the compiler doing something strange for index [const - const]
- "send telegram" doesn't work anymore, fixed
- add solarpump "softstart", i.e. mask out the first 100% value after pump-start
- add WW temp for 9000i in type-id 0x35, does not harm function of my boiler.