### PR TITLE
set first active hc for mqtt and terminal commands, some fixes for #410

### DIFF
--- a/src/device_library.h
+++ b/src/device_library.h
@@ -78,6 +78,7 @@
 
 // Mixing Modules - 0x20-0x27 for HC, 0x28-0x29 for WWC
 { 69, DeviceType::MIXING, F("MM10"), DeviceFlags::EMS_DEVICE_FLAG_MM10},
+{102, DeviceType::MIXING, F("IPM"), DeviceFlags::EMS_DEVICE_FLAG_IPM},
 {159, DeviceType::MIXING, F("MM50"), DeviceFlags::EMS_DEVICE_FLAG_MMPLUS},
 {160, DeviceType::MIXING, F("MM100"), DeviceFlags::EMS_DEVICE_FLAG_MMPLUS},
 {161, DeviceType::MIXING, F("MM200"), DeviceFlags::EMS_DEVICE_FLAG_MMPLUS},

--- a/src/devices/boiler.cpp
+++ b/src/devices/boiler.cpp
@@ -687,14 +687,21 @@ void Boiler::set_flow_temp(const uint8_t temperature) {
 
 // 1=hot, 2=eco, 3=intelligent
 void Boiler::set_warmwater_mode(const uint8_t comfort) {
+    uint8_t set;
     if (comfort == 1) {
         LOG_INFO(F("Setting boiler warm water to hot"));
+        set = 1;
     } else if (comfort == 2) {
         LOG_INFO(F("Setting boiler warm water to eco"));
+        set = 0;
     } else if (comfort == 3) {
         LOG_INFO(F("Setting boiler warm water to intelligent"));
+        set = 2;
     }
     write_command(EMS_TYPE_UBAParameterWW, 9, comfort);
+    // some boilers do not have this setting, than it's done by thermostat
+    // Test for RC35, but not a good way, we are here in boiler context.
+    // EMSESP::send_write_request(0x37, 0x10, 2, &set, 1, 0); // for RC35, maybe work also on RC300
 }
 
 // turn on/off warm water

--- a/src/devices/mixing.h
+++ b/src/devices/mixing.h
@@ -48,6 +48,7 @@ class Mixing : public EMSdevice {
 
     void process_MMPLUSStatusMessage_HC(std::shared_ptr<const Telegram> telegram);
     void process_MMPLUSStatusMessage_WWC(std::shared_ptr<const Telegram> telegram);
+    void process_IPMStatusMessage(std::shared_ptr<const Telegram> telegram);
     void process_MMStatusMessage(std::shared_ptr<const Telegram> telegram);
     void process_MMConfigMessage(std::shared_ptr<const Telegram> telegram);
     void process_MMSetMessage(std::shared_ptr<const Telegram> telegram);

--- a/src/devices/solar.cpp
+++ b/src/devices/solar.cpp
@@ -216,7 +216,11 @@ void Solar::process_SM100Energy(std::shared_ptr<const Telegram> telegram) {
 void Solar::process_ISM1StatusMessage(std::shared_ptr<const Telegram> telegram) {
     telegram->read_value(collectorTemp_, 4);   // Collector Temperature
     telegram->read_value(bottomTemp_, 6);      // Temperature Bottom of Solar Boiler
-    telegram->read_value(energyLastHour_, 0);  // Solar Energy produced in last hour - is * 10 and handled in ems-esp.cpp
+    uint16_t Wh = 0xFFFF;
+    telegram->read_value(Wh, 2);  // Solar Energy produced in last hour only ushort, is not * 10
+    if (Wh != 0xFFFF) {
+        energyLastHour_ = Wh * 10; // set to *10
+    }
     telegram->read_bitvalue(pump_, 8, 0);      // Solar pump on (1) or off (0)
     telegram->read_value(pumpWorkMin_, 10, 3); // force to 3 bytes
 }

--- a/src/devices/thermostat.h
+++ b/src/devices/thermostat.h
@@ -199,6 +199,7 @@ class Thermostat : public EMSdevice {
     static constexpr uint8_t EMS_OFFSET_JunkersSetMessage2_eco_temp      = 6;
     static constexpr uint8_t EMS_OFFSET_JunkersSetMessage3_heat          = 7;
 
+#define AUTO_HEATING_CIRCUIT 0
 #define DEFAULT_HEATING_CIRCUIT 1
 
     // Installation settings

--- a/src/emsdevice.h
+++ b/src/emsdevice.h
@@ -189,6 +189,7 @@ class EMSdevice {
     // Mixing Module
     static constexpr uint8_t EMS_DEVICE_FLAG_MMPLUS = 1;
     static constexpr uint8_t EMS_DEVICE_FLAG_MM10   = 2;
+    static constexpr uint8_t EMS_DEVICE_FLAG_IPM    = 3;
 
     // Thermostats
     static constexpr uint8_t EMS_DEVICE_FLAG_NO_WRITE  = (1 << 7); // last bit


### PR DESCRIPTION
i was also testing a bit with ww-mode in boiler, but i think it's not a good way. so it's only fyi and set inactive.
Why in #410 the controller is recognized as boiler is not clear to me, i think it's due to the same ProductID. 
Mixing and solar is taken from Norberts list.