### PR TITLE
clear devices before scan, hc's for master 0x18, set bus_id in web

### DIFF
--- a/interface/src/project/EMSESPSettingsController.tsx
+++ b/interface/src/project/EMSESPSettingsController.tsx
@@ -63,6 +63,19 @@ function EMSESPSettingsControllerForm(props: EMSESPSettingsControllerFormProps) 
                 onChange={handleValueChange('tx_mode')}
                 margin="normal"
             />
+            <SelectValidator name="ems_bus_id"
+                label="Bus Id"
+                value={data.ems_bus_id}
+                fullWidth
+                variant="outlined"
+                onChange={handleValueChange('ems_bus_id')}
+                margin="normal">
+                <MenuItem value={0x0B}>Servicekey (0x0B)</MenuItem>
+                <MenuItem value={0x0D}>Modem (0x0D)</MenuItem>
+                <MenuItem value={0x0A}>Terminal (0x0A)</MenuItem>
+                <MenuItem value={0x0F}>Time module (0x0F)</MenuItem>
+                <MenuItem value={0x12}>Alarm module (0x12)</MenuItem>
+            </SelectValidator>
             <BlockFormControlLabel
                 control={
                     <Checkbox

--- a/src/EMSESPDevicesService.cpp
+++ b/src/EMSESPDevicesService.cpp
@@ -39,6 +39,7 @@ EMSESPDevicesService::EMSESPDevicesService(AsyncWebServer * server, SecurityMana
 }
 
 void EMSESPDevicesService::scan_devices(AsyncWebServerRequest * request) {
+    EMSESP::clear_all_devices();
     EMSESP::send_read_request(EMSdevice::EMS_TYPE_UBADevices, EMSdevice::EMS_DEVICE_ID_BOILER);
     request->send(200);
 }

--- a/src/EMSESPDevicesService.h
+++ b/src/EMSESPDevicesService.h
@@ -25,7 +25,7 @@
 #include <SecurityManager.h>
 
 // #define MAX_EMSESP_STATUS_SIZE 1024
-#define MAX_EMSESP_DEVICE_SIZE 1280
+#define MAX_EMSESP_DEVICE_SIZE 1536
 
 #define EMSESP_DEVICES_SERVICE_PATH "/rest/allDevices"
 #define SCAN_DEVICES_SERVICE_PATH "/rest/scanDevices"

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -198,6 +198,7 @@ void EMSESPShell::add_console_commands() {
                           flash_string_vector{F_(deep_optional)},
                           [](Shell & shell, const std::vector<std::string> & arguments) {
                               if (arguments.size() == 0) {
+                                  EMSESP::clear_all_devices();
                                   EMSESP::send_read_request(EMSdevice::EMS_TYPE_UBADevices, EMSdevice::EMS_DEVICE_ID_BOILER);
                               } else {
                                   shell.printfln(F("Performing a deep scan..."));
@@ -223,6 +224,7 @@ void EMSESPShell::add_console_commands() {
                                   Device_Ids.push_back(0x1B); // Thermostat remote - 0x1B
                                   Device_Ids.push_back(0x11); // Switches - 0x11
 
+                                  EMSESP::clear_all_devices();
                                   // send the read command with Version command
                                   for (const uint8_t device_id : Device_Ids) {
                                       EMSESP::send_read_request(EMSdevice::EMS_TYPE_VERSION, device_id);

--- a/src/devices/boiler.cpp
+++ b/src/devices/boiler.cpp
@@ -99,8 +99,9 @@ void Boiler::device_info(JsonArray & root) {
 
 // publish values via MQTT
 void Boiler::publish_values() {
-    const size_t        capacity = JSON_OBJECT_SIZE(56); // must recalculate if more objects addded https://arduinojson.org/v6/assistant/
-    DynamicJsonDocument doc(capacity);
+    // const size_t        capacity = JSON_OBJECT_SIZE(56); // must recalculate if more objects addded https://arduinojson.org/v6/assistant/
+    // DynamicJsonDocument doc(capacity);
+    StaticJsonDocument<EMSESP_MAX_JSON_SIZE_LARGE> doc;
 
     char s[10]; // for formatting strings
 

--- a/src/devices/solar.cpp
+++ b/src/devices/solar.cpp
@@ -106,7 +106,8 @@ void Solar::show_values(uuid::console::Shell & shell) {
 
 // publish values via MQTT
 void Solar::publish_values() {
-    DynamicJsonDocument doc(EMSESP_MAX_JSON_SIZE_MEDIUM);
+    StaticJsonDocument<EMSESP_MAX_JSON_SIZE_MEDIUM> doc;
+    // DynamicJsonDocument doc(EMSESP_MAX_JSON_SIZE_MEDIUM);
 
     char s[10]; // for formatting strings
 

--- a/src/emsdevice.h
+++ b/src/emsdevice.h
@@ -47,16 +47,6 @@ class EMSdevice {
 
     virtual ~EMSdevice() = default; // destructor of base class must always be virtual because it's a polymorphic class
 
-    /*
-    // https://github.com/proddy/EMS-ESP/issues/434#issuecomment-667840531
-    inline uint8_t device_id(uint8_t hc = 0) const {
-        if (((device_id_ & 0x7F) >= 0x18) && ((device_id_ & 0x7F) <= 0x1B)) {
-            return ((device_id_ & 0x80) + 0x18 + hc);
-        }
-        return device_id_;
-    }
-    */
-
     inline uint8_t device_id() const {
         return device_id_;
     }

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -88,12 +88,37 @@ uint8_t EMSESP::count_devices(const uint8_t device_type) {
     return count;
 }
 
+void EMSESP::clear_all_devices() {
+    emsdevices.clear();
+}
+
 void EMSESP::actual_master_thermostat(const uint8_t device_id) {
     actual_master_thermostat_ = device_id;
 }
 
 uint8_t EMSESP::actual_master_thermostat() {
     return actual_master_thermostat_;
+}
+
+/**
+* if thermostat master is 0x18 it handles only ww and hc1, hc2..hc4 handled by devices 0x19..0x1B
+* we send to right device and match all reads to 0x18
+*/
+uint8_t EMSESP::check_master_device(const uint8_t device_id, const uint16_t type_id, const bool read) {
+    uint16_t mon_id[4] = {0x02A5, 0x02A6, 0x02A7, 0x02A8};
+    uint16_t set_id[4] = {0x02B9, 0x02BA, 0x02BB, 0x02BC};
+    if (actual_master_thermostat_  == 0x18) {
+        for (uint8_t i = 0; i < 4; i++) {
+            if (type_id == mon_id[i] || type_id == set_id[i]) {
+                if(read) {
+                    return 0x18;
+                } else {
+                    return 0x18 + i;
+                }
+            }
+        }
+    }
+    return device_id;
 }
 
 // to watch both type IDs and device IDs

--- a/src/emsesp.h
+++ b/src/emsesp.h
@@ -87,11 +87,14 @@ class EMSESP {
 
     static uint8_t actual_master_thermostat();
     static void    actual_master_thermostat(const uint8_t device_id);
+    static uint8_t check_master_device(const uint8_t device_id, const uint16_t type_id, const bool read);
 
     static void show_device_values(uuid::console::Shell & shell);
     static void show_sensor_values(uuid::console::Shell & shell);
 
     static void show_devices(uuid::console::Shell & shell);
+    static void clear_all_devices();
+
     static void show_ems(uuid::console::Shell & shell);
 
     static void add_context_menus();


### PR DESCRIPTION
I think i found a solution for RC200 as master on 0x18 and other RC200 for the other hc's. The first approach only manipulating device_id does not work, we have to check master and typ_id's too and spoof different for sending and receiving. 

The other small changes are self explaining. (boiler to Staticjson is only a few bytes saving in memory.)