### PR TITLE
Mixing MM100 fix pump/status, MM10 add valveStatus (-100%..100%)

### DIFF
--- a/src/devices/mixing.h
+++ b/src/devices/mixing.h
@@ -62,8 +62,8 @@ class Mixing : public EMSdevice {
   private:
     uint16_t hc_          = EMS_VALUE_USHORT_NOTSET;
     uint16_t flowTemp_    = EMS_VALUE_USHORT_NOTSET;
-    uint8_t  pumpMod_     = EMS_VALUE_UINT_NOTSET;
-    uint8_t  status_      = EMS_VALUE_UINT_NOTSET;
+    uint8_t  pump_        = EMS_VALUE_UINT_NOTSET;
+    int8_t   status_      = EMS_VALUE_UINT_NOTSET;
     uint8_t  flowSetTemp_ = EMS_VALUE_UINT_NOTSET;
     Type     type_        = Type::NONE;
     bool     changed_     = false;


### PR DESCRIPTION
Ok, here are the changes requested on gitter. I also checked my MM10 and add the valveStatus which goes from 9C..FF..00..64 i.e. signed -100 to 100 %. Norberts list only say `percent-value` for MM100 and IPM, if they are also signed, good, if not it does not harm. 