### PR TITLE
verify large offsets, readback setpoint roomtemp on `cmd:temp`

### DIFF
--- a/src/devices/thermostat.cpp
+++ b/src/devices/thermostat.cpp
@@ -1630,7 +1630,8 @@ void Thermostat::set_temperature(const float temperature, const uint8_t mode, co
             break;
         default:
         case HeatingCircuit::Mode::AUTO:
-            offset = 0x08; // auto offset
+            offset          = 0x08; // auto offset
+            validate_typeid = monitor_typeids[hc->hc_num() - 1]; // get setpoint roomtemp back
             break;
         }
 
@@ -1678,6 +1679,7 @@ void Thermostat::set_temperature(const float temperature, const uint8_t mode, co
             break;
         default:
         case HeatingCircuit::Mode::AUTO: // automatic selection, if no type is defined, we use the standard code
+            validate_typeid = monitor_typeids[hc->hc_num() - 1]; //get setpoint roomtemp back
             if (model == EMS_DEVICE_FLAG_RC35) {
                 uint8_t mode_ = hc->get_mode(this->flags());
                 if (mode_ == HeatingCircuit::Mode::NIGHT) {

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -131,12 +131,7 @@ uint8_t EMSESP::actual_master_thermostat() {
 
 // to watch both type IDs and device IDs
 void EMSESP::watch_id(uint16_t watch_id) {
-    // if it's a device ID, which is a single byte, remove the MSB so to support both Buderus and HT3 protocols
-    if (watch_id <= 0xFF) {
-        watch_id_ = (watch_id & 0x7F);
-    } else {
-        watch_id_ = watch_id;
-    }
+    watch_id_ = watch_id;
 }
 
 // change the tx_mode
@@ -491,7 +486,8 @@ bool EMSESP::process_telegram(std::shared_ptr<const Telegram> telegram) {
         LOG_NOTICE(pretty_telegram(telegram).c_str());
         read_id_ = WATCH_ID_NONE;
     } else if (watch() == WATCH_ON) {
-        if ((watch_id_ == WATCH_ID_NONE) || (telegram->src == watch_id_) || (telegram->dest == watch_id_) || (telegram->type_id == watch_id_)) {
+        if ((watch_id_ == WATCH_ID_NONE)  || (telegram->type_id == watch_id_) ||
+           ((watch_id_ < 0x80) && ((telegram->src == watch_id_) || (telegram->dest == watch_id_)))) {
             LOG_NOTICE(pretty_telegram(telegram).c_str());
         }
     }

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -73,7 +73,7 @@ Telegram::Telegram(const uint8_t   operation,
     , offset(offset)
     , message_length(message_length) {
     // copy complete telegram data over, preventing buffer overflow
-    for (uint8_t i = 0; ((i < message_length) && (i != EMS_MAX_TELEGRAM_MESSAGE_LENGTH - 1)); i++) {
+    for (uint8_t i = 0; ((i < message_length) && (i < EMS_MAX_TELEGRAM_MESSAGE_LENGTH)); i++) {
         message_data[i] = data[i];
     }
 }
@@ -189,7 +189,7 @@ void RxService::add(uint8_t * data, uint8_t length) {
         }
         type_id        = (data[4 + shift] << 8) + data[5 + shift] + 256;
         message_data   = data + 6 + shift;
-        message_length = length - 6 - shift;
+        message_length = length - 7 - shift;
     }
 
     // if we're watching and "raw" print out actual telegram as bytes to the console

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -195,7 +195,7 @@ void RxService::add(uint8_t * data, uint8_t length) {
     // if we're watching and "raw" print out actual telegram as bytes to the console
     if (EMSESP::watch() == EMSESP::Watch::WATCH_RAW) {
         uint16_t trace_watch_id = EMSESP::watch_id();
-        if ((trace_watch_id == WATCH_ID_NONE) || (src == trace_watch_id) || (dest == trace_watch_id) || (type_id == trace_watch_id)) {
+        if ((trace_watch_id == WATCH_ID_NONE)  || (type_id == trace_watch_id) || ((trace_watch_id < 0x80) && ((src == trace_watch_id) || (dest == trace_watch_id)))) {
             LOG_NOTICE(F("Rx: %s"), Helpers::data_to_hex(data, length).c_str());
         }
     }

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -584,8 +584,10 @@ uint16_t TxService::post_send_query() {
 
     if (post_typeid) {
         uint8_t dest            = (this->telegram_last_->dest & 0x7F);
+        // when set a value with large offset before and validate on same type, we have to add offset 0, 26, 52, ...
+        uint8_t offset          = (this->telegram_last_->type_id == post_typeid) ? ((this->telegram_last_->offset / 26) * 26) : 0;
         uint8_t message_data[1] = {EMS_MAX_TELEGRAM_LENGTH}; // request all data, 32 bytes
-        this->add(Telegram::Operation::TX_READ, dest, post_typeid, 0, message_data, 1, true);
+        this->add(Telegram::Operation::TX_READ, dest, post_typeid, offset, message_data, 1, true);
         // read_request(telegram_last_post_send_query_, dest, 0); // no offset
         LOG_DEBUG(F("Sending post validate read, type ID 0x%02X to dest 0x%02X"), post_typeid, dest);
         set_post_send_query(0); // reset


### PR DESCRIPTION
I've tried to change setpoint roomtemp `{"cmd":"temp", "data",...}` , writing seltemp at pos 37 does not give the right value back. Than i realized that i dont want to readback `seltemp` in this case, i want to change the actual setpoint, but that is in monitor message.