### PR TITLE
add dallas parasite setting (fix #490), sort settings page

### DIFF
--- a/interface/src/project/EMSESPSettingsController.tsx
+++ b/interface/src/project/EMSESPSettingsController.tsx
@@ -51,6 +51,10 @@ function EMSESPSettingsControllerForm(props: EMSESPSettingsControllerFormProps) 
                     Customize EMS-ESP by editing the default settings here. Refer to the <Link href="https://emsesp.github.io/docs/#/" color="primary">{'Wiki'}</Link>&nbsp;for descriptions of each setting.
                 </Typography>
             </Box>
+            <br></br>
+            <Typography variant="h6" color="primary" >
+                EMS Bus Settings
+            </Typography>
             <TextValidator
                 validators={['required', 'isNumber', 'minNumber:0', 'maxNumber:255']}
                 errorMessages={['TX mode is required', "Must be a number", "Must be 0 or higher", "Max value is 255"]}
@@ -100,6 +104,10 @@ function EMSESPSettingsControllerForm(props: EMSESPSettingsControllerFormProps) 
                 onChange={handleValueChange('tx_gpio')}
                 margin="normal"
             />
+            <br></br>
+            <Typography variant="h6" color="primary" >
+                Dallas Sensor Settings
+            </Typography>
             <TextValidator
                 validators={['required', 'isNumber', 'minNumber:0', 'maxNumber:40']}
                 errorMessages={['Dallas GPIO is required', "Must be a number", "Must be 0 or higher", "Max value is 255"]}
@@ -112,7 +120,21 @@ function EMSESPSettingsControllerForm(props: EMSESPSettingsControllerFormProps) 
                 onChange={handleValueChange('dallas_gpio')}
                 margin="normal"
             />
-            <TextValidator
+            <BlockFormControlLabel
+                control={
+                    <Checkbox
+                        checked={data.dallas_parasite}
+                        onChange={handleValueChange('dallas_parasite')}
+                        value="dallas_parasite"
+                    />
+                }
+                label="Dallas Parasite Mode"
+            />
+            <br></br>
+            <Typography variant="h6" color="primary" >
+                LED Settings
+            </Typography>
+           <TextValidator
                 validators={['required', 'isNumber', 'minNumber:0', 'maxNumber:40']}
                 errorMessages={['LED GPIO is required', "Must be a number", "Must be 0 or higher", "Max value is 255"]}
                 name="led_gpio"
@@ -134,6 +156,10 @@ function EMSESPSettingsControllerForm(props: EMSESPSettingsControllerFormProps) 
                 }
                 label="Invert/Hide LED"
             />
+            <br></br>
+            <Typography variant="h6" color="primary" >
+                Shower Settings
+            </Typography>
             <BlockFormControlLabel
                 control={
                     <Checkbox
@@ -154,6 +180,10 @@ function EMSESPSettingsControllerForm(props: EMSESPSettingsControllerFormProps) 
                 }
                 label="Shower Alert"
             />
+            <br></br>
+            <Typography variant="h6" color="primary" >
+                Syslog Settings
+            </Typography>
             <SelectValidator name="syslog_level"
                 label="Syslog Log Level"
                 value={data.syslog_level}

--- a/interface/src/project/EMSESPtypes.ts
+++ b/interface/src/project/EMSESPtypes.ts
@@ -7,11 +7,12 @@ export interface EMSESPSettings {
   master_thermostat: number;
   shower_timer: boolean;
   shower_alert: boolean;
-  hide_led: boolean;
   rx_gpio: number;
   tx_gpio : number;
   dallas_gpio : number;
+  dallas_parasite: boolean;
   led_gpio : number;
+  hide_led: boolean;
 }
 
 export enum busConnectionStatus {

--- a/src/EMSESPSettingsService.cpp
+++ b/src/EMSESPSettingsService.cpp
@@ -36,11 +36,12 @@ void EMSESPSettings::read(EMSESPSettings & settings, JsonObject & root) {
     root["master_thermostat"]    = settings.master_thermostat;
     root["shower_timer"]         = settings.shower_timer;
     root["shower_alert"]         = settings.shower_alert;
-    root["hide_led"]             = settings.hide_led;
     root["rx_gpio"]              = settings.rx_gpio;
     root["tx_gpio"]              = settings.tx_gpio;
     root["dallas_gpio"]          = settings.dallas_gpio;
+    root["dallas_parasite"]      = settings.dallas_parasite;
     root["led_gpio"]             = settings.led_gpio;
+    root["hide_led"]             = settings.hide_led;
 }
 
 StateUpdateResult EMSESPSettings::update(JsonObject & root, EMSESPSettings & settings) {
@@ -52,11 +53,12 @@ StateUpdateResult EMSESPSettings::update(JsonObject & root, EMSESPSettings & set
     settings.master_thermostat    = root["master_thermostat"] | EMSESP_DEFAULT_MASTER_THERMOSTAT;
     settings.shower_timer         = root["shower_timer"] | EMSESP_DEFAULT_SHOWER_TIMER;
     settings.shower_alert         = root["shower_alert"] | EMSESP_DEFAULT_SHOWER_ALERT;
-    settings.hide_led             = root["hide_led"] | EMSESP_DEFAULT_HIDE_LED;
     settings.rx_gpio              = root["rx_gpio"] | EMSESP_DEFAULT_RX_GPIO;
     settings.tx_gpio              = root["tx_gpio"] | EMSESP_DEFAULT_TX_GPIO;
     settings.dallas_gpio          = root["dallas_gpio"] | EMSESP_DEFAULT_DALLAS_GPIO;
+    settings.dallas_parasite      = root["dallas_parasite"] | EMSESP_DEFAULT_DALLAS_PARASITE;
     settings.led_gpio             = root["led_gpio"] | EMSESP_DEFAULT_LED_GPIO;
+    settings.hide_led             = root["hide_led"] | EMSESP_DEFAULT_HIDE_LED;
 
     return StateUpdateResult::CHANGED;
 }
@@ -68,6 +70,8 @@ void EMSESPSettingsService::onUpdate() {
     // EMSESP::system_.syslog_init(); // changing SysLog will require a restart
     EMSESP::init_tx();
     System::set_led();
+    Sensors sensors_;   // Dallas sensors
+    sensors_.start();
 }
 
 void EMSESPSettingsService::begin() {

--- a/src/EMSESPSettingsService.h
+++ b/src/EMSESPSettingsService.h
@@ -34,6 +34,7 @@
 #define EMSESP_DEFAULT_SHOWER_TIMER false
 #define EMSESP_DEFAULT_SHOWER_ALERT false
 #define EMSESP_DEFAULT_HIDE_LED false
+#define EMSESP_DEFAULT_DALLAS_PARASITE false
 
 // Default GPIO PIN definitions
 #if defined(ESP8266)
@@ -65,14 +66,15 @@ class EMSESPSettings {
     uint8_t  master_thermostat;
     bool     shower_timer;
     bool     shower_alert;
-    bool     hide_led;
     int8_t   syslog_level; // uuid::log::Level
     uint32_t syslog_mark_interval;
     String   syslog_host;
     uint8_t  rx_gpio;
     uint8_t  tx_gpio;
     uint8_t  dallas_gpio;
+    bool     dallas_parasite;
     uint8_t  led_gpio;
+    bool     hide_led;
 
     static void              read(EMSESPSettings & settings, JsonObject & root);
     static StateUpdateResult update(JsonObject & root, EMSESPSettings & settings);

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -111,6 +111,7 @@ class Sensors {
     uint8_t mqtt_format_;
     uint8_t retrycnt_    = 0;
     uint8_t dallas_gpio_ = 0;
+    bool    parasite_    = false;
     bool    changed_     = false;
 };
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -781,6 +781,9 @@ bool System::check_upgrade() {
                     settings.syslog_host          = EMSESP_DEFAULT_SYSLOG_HOST;
                     settings.syslog_level         = EMSESP_DEFAULT_SYSLOG_LEVEL;
                     settings.syslog_mark_interval = EMSESP_DEFAULT_SYSLOG_MARK_INTERVAL;
+                    settings.dallas_gpio          = custom_settings["dallas_gpio"] | EMSESP_DEFAULT_DALLAS_GPIO;
+                    settings.dallas_parasite      = custom_settings["dallas_parasite"] | EMSESP_DEFAULT_DALLAS_PARASITE;
+                    settings.led_gpio             = custom_settings["led_gpio"] | EMSESP_DEFAULT_LED_GPIO;
 
                     return StateUpdateResult::CHANGED;
                 },


### PR DESCRIPTION
I also tried to sort the settings like the sections in devices&sensors, take a look if you like it. (tried also with black boxes like tableheaders, but i like this more)
![settingspage](https://user-images.githubusercontent.com/59284019/92901273-a43fd900-f420-11ea-9ca5-5a3db642075d.png)
