### PR TITLE
remove mqtt custom, add thermostat wwtemps, mixing mqtt formats and a…

### DIFF
--- a/interface/src/mqtt/MqttSettingsForm.tsx
+++ b/interface/src/mqtt/MqttSettingsForm.tsx
@@ -116,7 +116,6 @@ class MqttSettingsForm extends React.Component<MqttSettingsFormProps> {
           <MenuItem value={1}>Single</MenuItem>
           <MenuItem value={2}>Nested</MenuItem>
           <MenuItem value={3}>Home Assistant</MenuItem>
-          <MenuItem value={4}>Custom</MenuItem>
         </SelectValidator>
         <SelectValidator name="mqtt_qos"
           label="QoS"

--- a/src/EMSESPAPIService.cpp
+++ b/src/EMSESPAPIService.cpp
@@ -67,21 +67,21 @@ void EMSESPAPIService::emsespAPIService(AsyncWebServerRequest * request) {
         id = request->getParam(F_(id))->value();
     }
 
+    if (id.isEmpty()) {
+        id = "-1";
+    }
+
     DynamicJsonDocument doc(EMSESP_MAX_JSON_SIZE_LARGE);
     JsonObject          output = doc.to<JsonObject>();
     bool                ok     = false;
 
     // execute the command
     if (data.isEmpty()) {
-        ok = Command::call(device_type, cmd.c_str(), nullptr, -1, output); // command only
+        ok = Command::call(device_type, cmd.c_str(), nullptr, id.toInt(), output); // command only
     } else {
         if (api_enabled) {
             // we only allow commands with parameters if the API is enabled
-            if (id.isEmpty()) {
-                ok = Command::call(device_type, cmd.c_str(), data.c_str(), -1, output); // only ID
-            } else {
-                ok = Command::call(device_type, cmd.c_str(), data.c_str(), id.toInt(), output); // has cmd, data and id
-            }
+            ok = Command::call(device_type, cmd.c_str(), data.c_str(), id.toInt(), output); // has cmd, data and id
         } else {
             request->send(401, "text/plain", F("Unauthorized"));
             return;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -40,7 +40,7 @@ bool Command::call(const uint8_t device_type, const char * cmd, const char * val
         LOG_DEBUG(F("[DEBUG] Calling command %s, value %s, id is %d in %s"), cmd, value, id, dname.c_str());
     }
 #endif
-
+    bool ok = false;
     if (!cmdfunctions_.empty()) {
         for (const auto & cf : cmdfunctions_) {
             if (cf.device_type_ == device_type) {
@@ -50,16 +50,17 @@ bool Command::call(const uint8_t device_type, const char * cmd, const char * val
                         // check if json object is empty, if so quit
                         if (output.isNull()) {
                             LOG_WARNING(F("Ignore call for command %s in %s because no json"), cmd, EMSdevice::device_type_2_device_name(device_type).c_str());
+                            return false;
                         }
-                        return ((cf.cmdfunction_json_)(value, id, output));
+                        ok |= ((cf.cmdfunction_json_)(value, id, output));
                     } else {
-                        return ((cf.cmdfunction_)(value, id));
+                        ok |= ((cf.cmdfunction_)(value, id));
                     }
                 }
             }
         }
     }
-    return false; // command not found
+    return ok;
 }
 
 // add a command to the list, which does not return json

--- a/src/devices/mixing.h
+++ b/src/devices/mixing.h
@@ -44,7 +44,7 @@ class Mixing : public EMSdevice {
   private:
     static uuid::log::Logger logger_;
 
-    bool export_values(JsonObject & doc);
+    bool export_values(uint8_t mqtt_format, JsonObject & doc);
     void register_mqtt_ha_config(const char * topic);
     bool command_info(const char * value, const int8_t id, JsonObject & output);
 

--- a/src/locale_EN.h
+++ b/src/locale_EN.h
@@ -214,11 +214,11 @@ MAKE_PSTR(tankHeated, "Tank Heated")
 MAKE_PSTR(collectorShutdown, "Collector shutdown")
 
 // mixing
-MAKE_PSTR(ww_hc, "Warm Water Circuit")
+MAKE_PSTR(ww_hc, "  Warm Water Circuit %d:")
 MAKE_PSTR(wwTemp, "Current warm water temperature")
 MAKE_PSTR(pumpStatus, "Current pump status")
 MAKE_PSTR(tempStatus, "Current temperature status")
-MAKE_PSTR(hc, "Heating Circuit")
+MAKE_PSTR(hc, "  Heating Circuit %d:")
 MAKE_PSTR(flowTemp, "Current flow temperature")
 MAKE_PSTR(flowSetTemp, "Setpoint flow temperature")
 
@@ -234,6 +234,8 @@ MAKE_PSTR(intoffset, "Offset int. temperature")
 MAKE_PSTR(minexttemp, "Min ext. temperature")
 MAKE_PSTR(building, "Building")
 MAKE_PSTR(wwmode, "Warm water mode")
+MAKE_PSTR(wwtemp, "Warm water high temperature")
+MAKE_PSTR(wwtemplow, "Warm water low temperature")
 MAKE_PSTR(wwcircmode, "Warm Water circulation mode")
 
 // thermostat - per heating circuit

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -79,7 +79,7 @@ class Mqtt {
 
     enum Operation { PUBLISH, SUBSCRIBE };
 
-    enum Format : uint8_t { NONE = 0, SINGLE, NESTED, HA, CUSTOM };
+    enum Format : uint8_t { NONE = 0, SINGLE, NESTED, HA };
 
     static constexpr uint8_t MQTT_TOPIC_MAX_SIZE = 100;
 

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -325,10 +325,7 @@ void Sensor::publish_values() {
     for (const auto & device : devices_) {
         char s[7];
 
-        if (mqtt_format_ == Mqtt::Format::CUSTOM) {
-            // e.g. sensor_data = {28-EA41-9497-0E03-5F":23.30,"28-233D-9497-0C03-8B":24.0}
-            doc[device.to_string()] = Helpers::render_value(s, device.temperature_c, 1);
-        } else if ((mqtt_format_ == Mqtt::Format::NESTED) || (mqtt_format_ == Mqtt::Format::HA)) {
+        if ((mqtt_format_ == Mqtt::Format::NESTED) || (mqtt_format_ == Mqtt::Format::HA)) {
             // e.g. sensor_data = {"sensor1":{"id":"28-EA41-9497-0E03-5F","temp":"23.30"},"sensor2":{"id":"28-233D-9497-0C03-8B","temp":"24.0"}}
             char sensorID[20]; // sensor{1-n}
             strlcpy(sensorID, "sensor", 20);
@@ -372,9 +369,7 @@ void Sensor::publish_values() {
         i++; // increment sensor count
     }
 
-    if (mqtt_format_ != Mqtt::Format::SINGLE) {
-        Mqtt::publish(F("sensor_data"), doc.as<JsonObject>());
-    }
+    Mqtt::publish(F("sensor_data"), doc.as<JsonObject>());
 }
 
 } // namespace emsesp


### PR DESCRIPTION
This are the changes for thermostat wwtemps and summermode.
For mixing i added a nested format, also the api-info-command have id for mixing circuit, or id empty should add all mixing devices to one json. But i can not test this, i have only one mixer (which is displayed as expected). Maybe this could also be a way to handle mqtt nested format for multible mixing devices. 
