### PR TITLE
sensornumbers and mqtt sensor formats

### DIFF
--- a/interface/src/project/EMSESPDevicesForm.tsx
+++ b/interface/src/project/EMSESPDevicesForm.tsx
@@ -179,18 +179,22 @@ class EMSESPDevicesForm extends Component<
           <Table size="small" padding="default">
             <TableHead>
               <TableRow>
-                <StyledTableCell>ID</StyledTableCell>
+                <StyledTableCell>Sensor no.</StyledTableCell>
+                <StyledTableCell align="center">ID</StyledTableCell>
                 <StyledTableCell align="right">Temperature</StyledTableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {data.sensors.map((sensorData) => (
-                <TableRow key={sensorData.id}>
+                <TableRow key={sensorData.no}>
                   <TableCell component="th" scope="row">
+                    Sensor&nbsp;{sensorData.no}
+                  </TableCell>
+                  <TableCell align="center">
                     {sensorData.id}
                   </TableCell>
                   <TableCell align="right">
-                    {sensorData.temp.toFixed(1)}&nbsp;&deg;C
+                    {sensorData.temp}&nbsp;&deg;C
                   </TableCell>
                 </TableRow>
               ))}

--- a/interface/src/project/EMSESPtypes.ts
+++ b/interface/src/project/EMSESPtypes.ts
@@ -43,8 +43,9 @@ export interface Device {
 }
 
 export interface Sensor {
+  no: number;
   id: string;
-  temp: number;
+  temp: string;
 }
 
 export interface EMSESPDevices {

--- a/src/EMSESPDevicesService.cpp
+++ b/src/EMSESPDevicesService.cpp
@@ -64,10 +64,14 @@ void EMSESPDevicesService::all_devices(AsyncWebServerRequest * request) {
 
     JsonArray sensors = root.createNestedArray("sensors");
     if (!EMSESP::sensor_devices().empty()) {
+        char    s[7];
+        uint8_t i = 1;
         for (const auto & sensor : EMSESP::sensor_devices()) {
             JsonObject obj = sensors.createNestedObject();
+            obj["no"]      = i;
             obj["id"]      = sensor.to_string();
-            obj["temp"]    = sensor.temperature_c;
+            obj["temp"]    = Helpers::render_value(s, sensor.temperature_c, 10);
+            i++;
         }
     }
 

--- a/src/devices/boiler.cpp
+++ b/src/devices/boiler.cpp
@@ -256,11 +256,11 @@ bool Boiler::export_values(JsonObject & output) {
     // Warm Water comfort setting
     if (Helpers::hasValue(wWComfort_)) {
         if (wWComfort_ == 0x00) {
-            output["wWComfort"] = "Hot";
+            output["wWComfort"] = F("Hot");
         } else if (wWComfort_ == 0xD8) {
-            output["wWComfort"] = "Eco";
+            output["wWComfort"] = F("Eco");
         } else if (wWComfort_ == 0xEC) {
-            output["wWComfort"] = "Intelligent";
+            output["wWComfort"] = F("Intelligent");
         }
     }
 
@@ -319,7 +319,7 @@ bool Boiler::export_values(JsonObject & output) {
 
     // Warm Water charging type
     if (Helpers::hasValue(wWChargeType_, EMS_VALUE_BOOL)) {
-        output["wWChargeType"] = wWChargeType_ ? F("3way valve") : F("charge pump");
+        output["wWChargeType"] = wWChargeType_ ? F("3way_valve") : F("chargepump");
     }
 
     // Warm Water circulation pump available bool

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -279,8 +279,10 @@ void EMSESP::show_sensor_values(uuid::console::Shell & shell) {
 
     char valuestr[8] = {0}; // for formatting temp
     shell.printfln(F("Dallas temperature sensors:"));
+    uint8_t i = 1;
     for (const auto & device : sensor_devices()) {
-        shell.printfln(F("  ID: %s, Temperature: %s°C"), device.to_string().c_str(), Helpers::render_value(valuestr, device.temperature_c, 1));
+        shell.printfln(F("  Sensor %d, ID: %s, Temperature: %s °C"), i, device.to_string().c_str(), Helpers::render_value(valuestr, device.temperature_c, 10));
+        i++;
     }
     shell.println();
 }

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -171,7 +171,7 @@ char * Helpers::render_value(char * result, uint8_t value, uint8_t format) {
         if (value == EMS_VALUE_BOOL_OFF) {
             render_boolean(result, false);
         } else if (value == EMS_VALUE_BOOL_NOTSET) {
-            return nullptr;
+            result[0] = '\0';
         } else {
             render_boolean(result, true); // assume on. could have value 0x01 or 0xFF
         }
@@ -179,7 +179,8 @@ char * Helpers::render_value(char * result, uint8_t value, uint8_t format) {
     }
 
     if (!hasValue(value)) {
-        return nullptr;
+        result[0] = '\0';
+        return result;
     }
 
     if (!format) {
@@ -209,9 +210,14 @@ char * Helpers::render_value(char * result, uint8_t value, uint8_t format) {
 char * Helpers::render_value(char * result, const float value, const uint8_t format) {
     long p[] = {0, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000};
 
+    result[0] = '\0';
+    if (value == NAN || format > 8) {
+        return result;
+    }
+
     char * ret   = result;
     long   whole = (long)value;
-    Helpers::itoa(result, whole, 10);
+    ltoa(whole, result, 10);
 
     while (*result != '\0') {
         result++;
@@ -219,7 +225,7 @@ char * Helpers::render_value(char * result, const float value, const uint8_t for
 
     *result++    = '.';
     long decimal = abs((long)((value - whole) * p[format]));
-    itoa(result, decimal, 10);
+    ltoa(decimal, result, 10);
 
     return ret;
 }
@@ -227,8 +233,9 @@ char * Helpers::render_value(char * result, const float value, const uint8_t for
 // int16: convert short (two bytes) to text string and returns string
 // format: 0=no division, other divide by the value given and render with a decimal point
 char * Helpers::render_value(char * result, const int16_t value, const uint8_t format) {
+    result[0] = '\0';
     if (!hasValue(value)) {
-        return nullptr;
+        return result;
     }
 
     // just print it if no conversion required (format = 0)
@@ -238,7 +245,6 @@ char * Helpers::render_value(char * result, const int16_t value, const uint8_t f
     }
 
     int16_t new_value = value;
-    result[0]         = '\0';
 
     // check for negative values
     if (new_value < 0) {
@@ -267,7 +273,8 @@ char * Helpers::render_value(char * result, const int16_t value, const uint8_t f
 // uint16: convert unsigned short (two bytes) to text string and prints it
 char * Helpers::render_value(char * result, const uint16_t value, const uint8_t format) {
     if (!hasValue(value)) {
-        return nullptr;
+        result[0] = '\0';
+        return result;
     }
     return (render_value(result, (int16_t)value, format)); // use same code, force it to a signed int
 }
@@ -275,7 +282,8 @@ char * Helpers::render_value(char * result, const uint16_t value, const uint8_t 
 // int8: convert signed byte to text string and prints it
 char * Helpers::render_value(char * result, const int8_t value, const uint8_t format) {
     if (!hasValue(value)) {
-        return nullptr;
+        result[0] = '\0';
+        return result;
     }
     return (render_value(result, (int16_t)value, format)); // use same code, force it to a signed int
 }
@@ -283,7 +291,8 @@ char * Helpers::render_value(char * result, const int8_t value, const uint8_t fo
 // uint32: render long (4 byte) unsigned values
 char * Helpers::render_value(char * result, const uint32_t value, const uint8_t format) {
     if (!hasValue(value)) {
-        return nullptr;
+        result[0] = '\0';
+        return result;
     }
 
     char s[20];

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -46,11 +46,11 @@ class Sensor {
         uint64_t    id() const;
         std::string to_string() const;
 
-        float temperature_c = NAN;
+        int16_t temperature_c = EMS_VALUE_SHORT_NOTSET;
+        bool    read          = false;
 
       private:
         const uint64_t id_;
-        bool           registered_ = false;
     };
 
     Sensor()  = default;
@@ -100,18 +100,19 @@ class Sensor {
     OneWire bus_;
 #endif
 
-    bool  temperature_convert_complete();
-    float get_temperature_c(const uint8_t addr[]);
+    bool     temperature_convert_complete();
+    int16_t  get_temperature_c(const uint8_t addr[]);
+    uint64_t get_id(const uint8_t addr[]);
 
     uint32_t            last_activity_ = uuid::get_uptime();
     uint32_t            last_publish_  = uuid::get_uptime();
     State               state_         = State::IDLE;
-    std::vector<Device> found_;
     std::vector<Device> devices_;
 
     bool registered_ha_[MAX_SENSORS];
 
-    uint8_t retrycnt_    = 0;
+    int8_t  scancnt_     = -3;
+    uint8_t firstscan_   = 0;
     uint8_t dallas_gpio_ = 0;
     bool    parasite_    = false;
     bool    changed_     = false;


### PR DESCRIPTION
This is my suggestion for the sensor change, please check the HA-discovery, i'm not sure that this works with name `sensor x` and unique-ID.
I need to change some Helpers, rendering missing floats (NAN) give always `-1.-1` which looks odd, At least i change sensors to int16. Also returning nullptr gives in json `{"temp":NULL}`, now changed to `{"temp":""}` 

The formats are now all to topic `sensor_data`, single `{"sensor1":"23.1","sensor2":"20.5"}, nested as before and HA with ID `{"28-xxxx-xxxx-xxxx":"23.1"}` and discovery changed to that format. 

For the boiler i thought that the space in `3-way valve` is critical in 556, not the dash, but also not sure.